### PR TITLE
[7.x] Convert to SystemQueue.

### DIFF
--- a/modules/quant_api/quant_api.admin.inc
+++ b/modules/quant_api/quant_api.admin.inc
@@ -20,7 +20,7 @@ function quant_api_settings() {
   );
 
   $form['quant_api_token'] = array(
-    '#type' => 'textfield',
+    '#type' => 'password',
     '#title' => t('API Token'),
     '#decription' => t('The API token'),
   );

--- a/modules/quant_api/quant_api.module
+++ b/modules/quant_api/quant_api.module
@@ -152,10 +152,16 @@ function quant_api_quant_seed($location, $data, $meta = [], $context = []) {
 
     $loc = DRUPAL_ROOT . $on_disk;
 
+    // Override if this looks like a private file.
+    if (strpos($file, '/system/files/') !== FALSE) {
+      $private_path = drupal_realpath('private://');
+      $loc = str_replace('/system/files', $private_path, $file);
+    }
+
     if (!file_exists($loc)) {
       quant_log('File not found: %file', array(
         '%file' => $file,
-      ));
+      ), QUANT_VERBOSE);
       continue;
     }
 
@@ -167,6 +173,9 @@ function quant_api_quant_seed($location, $data, $meta = [], $context = []) {
     // @TODO - this processes inline in the batch request
     // which might cause performance problems with pages with
     // many assets.
+    if (!empty($item['full_path'])) {
+      $file = $item['full_path'];
+    }
     quant_seed_file($file, [
       'location' => $loc,
       'request' => $on_disk,
@@ -179,6 +188,8 @@ function quant_api_quant_seed($location, $data, $meta = [], $context = []) {
  * Implements hook_quant_seed_file().
  */
 function quant_api_quant_seed_file($url, $context) {
+  global $base_url;
+
   $api = variable_get('quant_api_endpoint', QUANT_API_ENDPOINT_DEFAULT) . '/v1';
 
   if (empty($api)) {
@@ -191,6 +202,44 @@ function quant_api_quant_seed_file($url, $context) {
     return;
   }
 
+  if (!file_exists($context['location'])) {
+    quant_log('Unable to upload %u, file does not exist', ['%u' => $context['location']]);
+    return;
+  }
+
+  // Issue a HEAD request to the file path.
+  $options = array(
+    'headers' => array(
+      'Host' => variable_get('quant_hostname', parse_url($base_url, PHP_URL_HOST)),
+      'User-Agent' => 'Quant (+http://quantcdn.io)',
+    ),
+    'method' => 'HEAD',
+  );
+
+  // Ensure url is absolute for internal HEAD request.
+  if(strpos($url, "http") !== 0) {
+    $base = variable_get('quant_base_url', $base_url);
+    $url = "{$base}{$url}";
+  }
+
+  $file_head = drupal_http_request($url, $options);
+
+  // Disallow files that do not return 200 OK.
+  if ($file_head->code != 200) {
+    quant_log('Unable to seed file: %url. Unexpected response code: %code', array(
+      '%url' => $url,
+      '%code' => $file_head->code,
+    ), WATCHDOG_ERROR);
+    return;
+  }
+
+  // Support file specific additional headers.
+  $custom_headers = array_intersect_key($file_head->headers, array_flip(array(
+    'content-disposition',
+    'content-transfer-encoding',
+    'content-type'
+  )));
+
   $headers = quant_api_get_request_headers() + array(
     'Quant-File-Url' => $context['request'],
     'User-Agent' => 'Quant (+http://quant.io)',
@@ -199,6 +248,11 @@ function quant_api_quant_seed_file($url, $context) {
   $curl_headers = array();
   foreach ($headers as $header => $value) {
     $curl_headers[] = "{$header}: {$value}";
+  }
+
+  // Add extra file headers if relevant.
+  if (!empty($custom_headers)) {
+    $curl_headers[] = "Quant-File-Headers: " . json_encode($custom_headers);
   }
 
   // Drupal HTTP request doesn't support streaming files - so we need
@@ -228,7 +282,7 @@ function quant_api_quant_seed_file($url, $context) {
     return FALSE;
   }
 
-  if (!empty($response->error)) {
+  if (!empty($response->error) && strpos("MD5 already matches", $response->error) !== FALSE) {
     quant_log('Error sending request: %error', array(
       '%error' => $response->errorMsg,
     ), WATCHDOG_ERROR);

--- a/modules/quant_api/quant_api.module
+++ b/modules/quant_api/quant_api.module
@@ -10,7 +10,7 @@
  *
  * @var string
  */
-define('QUANT_API_ENDPOINT_DEFAULT', 'https://api.quantcdn.io/');
+define('QUANT_API_ENDPOINT_DEFAULT', 'https://api.quantcdn.io');
 
 /**
  * Implements hook_help().
@@ -179,7 +179,7 @@ function quant_api_quant_seed($location, $data, $meta = [], $context = []) {
  * Implements hook_quant_seed_file().
  */
 function quant_api_quant_seed_file($url, $context) {
-  $api = variable_get('quant_api_endpoint', QUANT_API_ENDPOINT_DEFAULT);
+  $api = variable_get('quant_api_endpoint', QUANT_API_ENDPOINT_DEFAULT) . '/v1';
 
   if (empty($api)) {
     quant_log('API endpoint is not configured.', [], 'info');
@@ -248,7 +248,7 @@ function quant_api_quant_seed_file($url, $context) {
  *   If the request was successful.
  */
 function quant_api_unpublish_route($url) {
-  $api = variable_get('quant_api_endpoint', QUANT_API_ENDPOINT_DEFAULT);
+  $api = variable_get('quant_api_endpoint', QUANT_API_ENDPOINT_DEFAULT) . '/v1';
 
   $options = array(
     'headers' => quant_api_get_request_headers() + array(

--- a/modules/quant_file/quant_file.module
+++ b/modules/quant_file/quant_file.module
@@ -50,12 +50,14 @@ function quant_file_form_quant_seed_settings_alter(&$form, $form_state) {
 }
 
 /**
- * Implements hook_quant_seed_alter().
+ * Implements hook_quant_seed_queue().
  */
-function quant_file_quant_seed_alter(&$batch) {
+function quant_file_quant_seed_queue() {
   if (!variable_get('quant_seed_files', FALSE)) {
     return;
   }
+
+  $queue = quant_get_queue();
 
   $files = db_select('file_managed', 'f')
     ->fields('f', array('fid', 'status'))
@@ -64,10 +66,11 @@ function quant_file_quant_seed_alter(&$batch) {
 
   while ($file = $files->fetchAssoc()) {
     list($url, $context) = _quant_prepare_entity('file', $file['fid']);
-    $batch['operations'][] = array(
+    $item = array(
       'quant_seed',
       array($url, $context),
     );
+    $queue->createItem($item);
   }
 }
 

--- a/modules/quant_file/quant_file.module
+++ b/modules/quant_file/quant_file.module
@@ -25,6 +25,7 @@ function quant_file_file_insert($file) {
  * Implements hook_file_update().
  */
 function quant_file_file_update($file) {
+
   $original = isset($file->original) ? $file->original : NULL;
   $entity_info = array(
     'entity' => $file,

--- a/modules/quant_redirect/quant_redirect.module
+++ b/modules/quant_redirect/quant_redirect.module
@@ -53,18 +53,20 @@ function quant_redirect_request($from, $to, $status = 301, $published = TRUE, $i
 
   $api .= '/redirect';
 
+  $data = json_encode(array(
+    'url' => '/' . ltrim($from, '/'),
+    'redirect_url' => $to,
+    'redirect_http_code' => $status,
+    'published' => (bool) $published,
+  ));
+
   $request = array(
     'headers' => quant_api_get_request_headers() + array(
       'content-type' => 'application/json',
       'User-Agent' => 'Quant (+http://quant.io)',
     ),
     'method' => 'POST',
-    'data' => json_encode(array(
-      'url' => '/' . ltrim($from, '/'),
-      'redirect_url' => $to,
-      'redirect_http_code' => $status,
-      'published' => (bool) $published,
-    )),
+    'data' => $data,
   );
 
   // If the redirect is not new then we need to unpublish the URL
@@ -84,10 +86,9 @@ function quant_redirect_request($from, $to, $status = 301, $published = TRUE, $i
   $response = drupal_http_request($api, $request);
 
   if (!empty($response->error)) {
-    quant_log('Unable to seed redirect: %error %payload %res', array(
+    quant_log('Unable to seed redirect: %data (%error)', array(
       '%error' => $response->error,
-      '%payload' => json_encode($request),
-      '%res' => json_encode($response),
+      '%data' => json_encode($data),
     ), WATCHDOG_ERROR);
   }
 
@@ -139,4 +140,20 @@ function quant_redirect_quant_seed_queue() {
 
     $queue->createItem($item);
   }
+}
+
+
+/**
+ * Implements hook_quant_seed().
+ *
+ * Generates canonical redirects for entities (file, taxonomy, node).
+ */
+function quant_redirect_quant_seed($location, $data, $meta = [], $context = []) {
+
+  if (empty($context) || !isset($context['type'])) {
+    return;
+  }
+
+  // @todo: generate canonical redirects (e.g node/123 or taxonomy/term/123)
+
 }

--- a/modules/quant_redirect/quant_redirect.module
+++ b/modules/quant_redirect/quant_redirect.module
@@ -106,12 +106,14 @@ function quant_redirect_form_quant_seed_settings_alter(&$form, $form_state) {
 }
 
 /**
- * Implements hook_quant_seed_alter().
+ * Implements hook_quant_seed_queue().
  */
-function quant_redirect_quant_seed_alter(&$batch) {
+function quant_redirect_quant_seed_queue() {
   if (!variable_get('quant_seed_redirects', FALSE)) {
     return;
   }
+
+  $queue = quant_get_queue();
 
   $redirects = db_select('redirect', 'r')
     ->fields('r', array('source', 'redirect', 'status_code'))
@@ -130,9 +132,11 @@ function quant_redirect_quant_seed_alter(&$batch) {
       );
     }
 
-    $batch['operations'][] = array(
+    $item = array(
       'quant_redirect_request',
       array($redirect['source'], $redirect['redirect'], $status_code),
     );
+
+    $queue->createItem($item);
   }
 }

--- a/modules/quant_sitemap/quant_sitemap.module
+++ b/modules/quant_sitemap/quant_sitemap.module
@@ -17,19 +17,21 @@ function quant_sitemap_form_quant_seed_settings_alter(&$form, $form_state) {
 }
 
 /**
- * Implements hook_quant_seed_alter().
+ * Implements hook_quant_seed_queue().
  */
-function quant_sitemap_quant_seed_alter(&$batch) {
+function quant_sitemap_quant_seed_queue() {
   if (!variable_get('quant_seed_sitemap', FALSE)) {
     return;
   }
 
+  $queue = quant_get_queue();
   $sitemaps = xmlsitemap_sitemap_load_multiple(FALSE);
 
   foreach ($sitemaps as $sitemap) {
-    $batch['operations'][] = array(
+    $item = array(
       'quant_seed',
       array(url($sitemap->uri['path'], $sitemap->uri['options'])),
     );
+    $queue->createItem($item);
   }
 }

--- a/quant.admin.inc
+++ b/quant.admin.inc
@@ -99,7 +99,6 @@ function quant_config() {
  */
 function quant_seed_settings() {
   $form = array();
-
   _quant_get_seed_warnings($form);
 
   $form['quant_seed_entity_node'] = array(
@@ -191,4 +190,57 @@ function quant_seed_settings() {
   $form['#submit'][] = '_quant_queue_batch';
 
   return $form;
+}
+
+/**
+ * Present items that are queued for quant sending.
+ */
+function quant_queue_page() {
+  $items = quant_get_queue(TRUE);
+  $rows = [];
+
+  $header = array(
+    t('Item ID'),
+    t('Claimed/Expiration'),
+    t('Created'),
+    t('Content/Data'),
+  );
+
+  foreach ($items as &$item) {
+    if ($item['expire'] > 0) {
+      $item['expire'] = t("Claimed: expires %expire", array('%expire' => date('r', $item['expire'])));
+    } else {
+      $item['expire'] = t('Unclaimed');
+    }
+    $item['created'] = date('r', $item['created']);
+    list($op, $context) = unserialize($item['data']);
+    $item['content'] = t('<b>Callback:</b> %op<br /><b>URL:</b> %arg', array(
+      '%op' => $op,
+      '%arg' => reset($context),
+    ));
+    unset($item['data']);
+    $rows[] = $item;
+  }
+
+  if (!empty($items)) {
+    $queue = quant_get_queue();
+    $build['desc'] = array(
+      '#markup' => t('There are <b>%total</b> items in the queue.<br/><br />', array(
+        '%total' => $queue->numberOfItems(),
+      )),
+    );
+  }
+
+  $build['pager_table'] = array(
+    '#theme' => 'table',
+    '#header' => $header,
+    '#rows' => $rows,
+    '#empty' => t('There are no items in the queue.'),
+  );
+
+  $build['pager'] = array(
+    '#theme' => 'pager',
+  );
+
+  return $build;
 }

--- a/quant.admin.inc
+++ b/quant.admin.inc
@@ -209,7 +209,8 @@ function quant_queue_page() {
   foreach ($items as &$item) {
     if ($item['expire'] > 0) {
       $item['expire'] = t("Claimed: expires %expire", array('%expire' => date('r', $item['expire'])));
-    } else {
+    }
+    else {
       $item['expire'] = t('Unclaimed');
     }
     $item['created'] = date('r', $item['created']);

--- a/quant.admin.inc
+++ b/quant.admin.inc
@@ -119,6 +119,7 @@ function quant_seed_settings() {
     '#type' => 'checkboxes',
     '#title' => t('Enabled bundles'),
     '#description' => t('Optionally restrict to these content types.'),
+    '#default_value' => variable_get('quant_seed_entity_node_bundles', FALSE),
     '#options' => $options,
     '#states' => array(
       'visible' => array(
@@ -151,10 +152,11 @@ function quant_seed_settings() {
   // @TODO - add media entity support.
   $form['entity_media'] = array();
 
-  $form['routes'] = [
+  $form['quant_custom_routes_enabled'] = [
     '#type' => 'checkbox',
     '#title' => t('Custom routes'),
     '#description' => t('Exports custom list of routes.'),
+    '#default_value' => variable_get('quant_custom_routes_enabled', FALSE),
   ];
 
   $form['quant_custom_routes'] = [
@@ -163,7 +165,7 @@ function quant_seed_settings() {
     '#description' => t('Add routes to export, each on a new line. Routes must not include domain and start with a slash, e.g: /about-us'),
     '#states' => [
       'visible' => [
-        ':input[name="routes"]' => ['checked' => TRUE],
+        ':input[name="quant_custom_routes_enabled"]' => ['checked' => TRUE],
       ],
     ],
     '#default_value' => variable_get('quant_custom_routes', FALSE),
@@ -184,10 +186,15 @@ function quant_seed_settings() {
 
   $form = system_settings_form($form);
 
-  $form['actions']['#weight'] = 999;
-
-  $form['#submit'][] = '_quant_seed_prepare';
+  $form['actions']['#weight'] = 998;
   $form['#submit'][] = '_quant_queue_batch';
+
+  $form['save_and_queue'] = array(
+    '#type' => 'submit',
+    '#value' => 'Save and Queue',
+    '#submit' => array('_quant_seed_prepare'),
+    '#weight' => 999,
+  );
 
   return $form;
 }

--- a/quant.admin.inc
+++ b/quant.admin.inc
@@ -174,7 +174,7 @@ function quant_seed_settings() {
   $form['quant_robots'] = [
     '#type' => 'checkbox',
     '#title' => t('Export robots.txt'),
-    '#default_value' => variable_geT('quant_robots', FALSE),
+    '#default_value' => variable_get('quant_robots', FALSE),
   ];
 
   $form['trigger_quant_seed'] = array(
@@ -251,4 +251,41 @@ function quant_queue_page() {
   );
 
   return $build;
+}
+
+/**
+ * Quant token settings form.
+ */
+function quant_token_settings() {
+  $form = array();
+  $form['quant_token_timeout'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Token timeout'),
+    '#description' => t('A string compatible with <a href="https://www.php.net/manual/en/function.strtotime.php">PHPs baseTimestamp</a> parameter'),
+    '#default_value' => variable_get('quant_token_timeout', '+1 minute'),
+  );
+  $form['quant_token_strict'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable strict token checks'),
+    '#description' => t('This enforces strict token checking during seeds'),
+    '#default_value' => variable_get('quant_token_strict', true),
+  );
+  $form['quant_token_secret_regenerate'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Regerenate signing secret'),
+    '#description' => t('This will regenerate the internal secret value Quant uses to sign internal requests'),
+  );
+
+  $form = system_settings_form($form);
+  $form['#submit'][] = 'quant_token_regenerate';
+  return $form;
+}
+
+/**
+ * Regenerate quant signing secret.
+ */
+function quant_token_regenerate($form, &$form_state) {
+  if ($form_state['values']['quant_token_secret_regenerate']) {
+    variable_set('quant_token_secret', bin2hex(random_bytes(32)));
+  }
 }

--- a/quant.admin.inc
+++ b/quant.admin.inc
@@ -176,7 +176,7 @@ function quant_seed_settings() {
     '#default_value' => variable_geT('quant_robots', FALSE),
   ];
 
-  $form['quant_seed'] = array(
+  $form['trigger_quant_seed'] = array(
     '#type' => 'checkbox',
     '#title' => t('Trigger the batch'),
     '#description' => t('<strong>Note:</strong> This will attempt to trigger the seed from the UI, depending on the size of your site and PHP configuration this may not work.'),
@@ -188,6 +188,7 @@ function quant_seed_settings() {
   $form['actions']['#weight'] = 999;
 
   $form['#submit'][] = '_quant_seed_prepare';
+  $form['#submit'][] = '_quant_queue_batch';
 
   return $form;
 }

--- a/quant.admin.inc
+++ b/quant.admin.inc
@@ -16,7 +16,7 @@ function quant_config() {
     '#type' => 'checkbox',
     '#title' => t('Track content changes'),
     '#description' => t('Automatically push content changes to Quant (recommended).'),
-    '#default_value' => variable_get('quant_enabled', FALSE),
+    '#default_value' => variable_get('quant_enabled', TRUE),
   );
 
   $form['tracking_fieldset'] = [
@@ -32,33 +32,33 @@ function quant_config() {
   $form['tracking_fieldset']['quant_enabled_nodes'] = [
     '#type' => 'checkbox',
     '#title' => t('Nodes'),
-    '#default_value' => variable_get('quant_enabled_nodes'),
+    '#default_value' => variable_get('quant_enabled_nodes', TRUE),
   ];
 
   $form['tracking_fieldset']['quant_enabled_taxonomy'] = [
     '#type' => 'checkbox',
     '#title' => t('Taxonomy Terms'),
-    '#default_value' => variable_get('quant_enabled_taxonomy'),
+    '#default_value' => variable_get('quant_enabled_taxonomy', TRUE),
   ];
 
   $form['tracking_fieldset']['quant_enabled_views'] = [
     '#type' => 'checkbox',
     '#title' => t('Views'),
-    '#default_value' => variable_get('quant_enabled_views'),
+    '#default_value' => variable_get('quant_enabled_views', TRUE),
   ];
 
   $form['disable_content_drafts'] = array(
     '#type' => 'checkbox',
     '#title' => t('Disable content drafts'),
     '#description' => t('Prevent draft content from being sent to Quant.'),
-    '#default_value' => variable_get('disable_content_drafts', FALSE),
+    '#default_value' => variable_get('disable_content_drafts', TRUE),
   );
 
   $form['quant_rewrite_relative'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable relative paths'),
     '#description' => t('Ensure all assets are rewritten as relative paths.'),
-    '#default_value' => variable_get('quant_rewrite_relative', FALSE),
+    '#default_value' => variable_get('quant_rewrite_relative', TRUE),
   );
 
   $form['quant_proxy_override'] = array(
@@ -192,7 +192,7 @@ function quant_seed_settings() {
   $form['save_and_queue'] = array(
     '#type' => 'submit',
     '#value' => 'Save and Queue',
-    '#submit' => array('_quant_seed_prepare'),
+    '#submit' => array('system_settings_form_submit', '_quant_seed_prepare'),
     '#weight' => 999,
   );
 
@@ -257,19 +257,31 @@ function quant_queue_page() {
  * Quant token settings form.
  */
 function quant_token_settings() {
+
   $form = array();
+
+  $form['quant_token_disable'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Disable token verification'),
+    '#description' => t('Not recommended for production environments, this disables token verification.'),
+    '#default_value' => variable_get('quant_token_disable', FALSE),
+  );
+
+
   $form['quant_token_timeout'] = array(
     '#type' => 'textfield',
     '#title' => t('Token timeout'),
     '#description' => t('A string compatible with <a href="https://www.php.net/manual/en/function.strtotime.php">PHPs baseTimestamp</a> parameter'),
     '#default_value' => variable_get('quant_token_timeout', '+1 minute'),
   );
+
   $form['quant_token_strict'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable strict token checks'),
     '#description' => t('This enforces strict token checking during seeds'),
     '#default_value' => variable_get('quant_token_strict', true),
   );
+
   $form['quant_token_secret_regenerate'] = array(
     '#type' => 'checkbox',
     '#title' => t('Regerenate signing secret'),

--- a/quant.api.inc
+++ b/quant.api.inc
@@ -6,6 +6,25 @@
  */
 
 /**
+ * Add items to the quant_queue.
+ *
+ * This hook is called when Quant is gathering the routes
+ * that it needs to send to the hosted service. This will
+ * allow a module to hook into the collection process and
+ * provide data for the seed process.
+ *
+ * Any items added to the quant queue needs to follow the
+ * same structure as a batch operation; an array that has
+ * callback and arguments as each item will be executed
+ * with call_user_func_array.
+ */
+function hook_quant_seed_queue() {
+  $queue = quant_get_queue();
+  $item = array('callback', array('context'));
+  $queue->createItem($item);
+}
+
+/**
  * Invoked after the entity has been rendered.
  *
  * This function will recieve the data that is to be
@@ -15,9 +34,59 @@
  *   The location the file should be stored.
  * @param string $data
  *   String data to be stored.
+ * @param array $meta
+ *   The collected metadata about the route.
+ * @param array $context
+ *   The entity context for the route.
  */
-function hook_quant_seed($location, $data) {
+// phpcs:ignore
+function hook_quant_seed($location, $data, $meta, $context) {
   // Send the data to the configured API.
+}
+
+
+/**
+ * Invoked after the entity has been rendered.
+ *
+ * This function will recieve the data that is to be
+ * seeded to the storage interface.
+ *
+ * @param string $location
+ *   The location the file should be stored.
+ * @param array $context
+ *   The entity context for the route.
+ */
+// phpcs:ignore
+function hook_quant_seed_file($url, $context) {
+  // Send the data to the configured API.
+}
+
+/**
+ * Provide additional data about for a route.
+ *
+ * Allows modules to hook in and change or add to
+ * the core provided meta data for Quant files.
+ *
+ * @param array $meta
+ *   The metadata array.
+ */
+// phpcs:ignore
+function hook_quant_meta_alter($meta) {
+  // Change add to the meta array.
+}
+
+/**
+ * Targeted meta provider.
+ *
+ * Allows modules to hook in and change or add to
+ * the core provided meta data for Quant files.
+ *
+ * @param array $meta
+ *   The metadata array.
+ */
+// phpcs:ignore
+function hook_quant_meta_TYPE_alter($meta) {
+  // Change add to the meta array.
 }
 
 /**
@@ -30,6 +99,6 @@ function hook_quant_seed($location, $data) {
  *   The metadata array.
  */
 // phpcs:ignore
-function hook_quant_meta_alter($meta) {
-  // Change add to the meta array.
+function hook_quant_file_meta_alter(&$meta, $context) {
+  // Change add meta specific to files.
 }

--- a/quant.api.inc
+++ b/quant.api.inc
@@ -44,7 +44,6 @@ function hook_quant_seed($location, $data, $meta, $context) {
   // Send the data to the configured API.
 }
 
-
 /**
  * Invoked after the entity has been rendered.
  *

--- a/quant.drush.inc
+++ b/quant.drush.inc
@@ -10,6 +10,14 @@
  */
 function quant_drush_command() {
 
+  $items['quant-queue-info'] = array(
+    'callback' => 'drush_quant_info',
+    'description' => 'Return current queue count.',
+    'arguments' => array(),
+    'options' => array(),
+    'aliases' => array('qi'),
+  );
+
   $items['quant-seed-queue'] = array(
     'callback' => 'drush_quant_seed',
     'description' => 'Populate the queue',
@@ -33,10 +41,18 @@ function quant_drush_command() {
     'description' => 'Reset the queue',
     'arguments' => array(),
     'options' => array(),
-    'aliases' => array('qr'),
+    'aliases' => array('qc'),
   );
 
   return $items;
+}
+
+/**
+ * Callback to return current queue count.
+ */
+function drush_quant_info() {
+  $queue = quant_get_queue();
+  drush_log($queue->numberOfItems() . ' items in the queue.', 'ok');
 }
 
 /**

--- a/quant.drush.inc
+++ b/quant.drush.inc
@@ -44,7 +44,7 @@ function drush_quant_seed() {
     drush_log('Quant API project is not configured', 'error');
   }
 
-  drush_log("Seeding for $customer with $token", 'ok');
+  drush_log("Seeding for $customer: $project", 'ok');
 
   _quant_seed_prepare();
 

--- a/quant.drush.inc
+++ b/quant.drush.inc
@@ -10,23 +10,80 @@
  */
 function quant_drush_command() {
 
-  $items['quant-seed'] = array(
+  $items['quant-seed-queue'] = array(
     'callback' => 'drush_quant_seed',
-    'description' => 'Seed nodes',
+    'description' => 'Populate the queue',
     'arguments' => array(),
     'options' => array(),
     'aliases' => array('qs'),
+  );
+
+  $items['quant-run-queue'] = array(
+    'callback' => 'drush_quant_process_queue',
+    'description' => 'Process the queue, push content to Quant',
+    'arguments' => array(),
+    'options' => array(
+      'threads' => 'Number of concurrent threads. Default is 5, increase to improve seed performance.',
+    ),
+    'aliases' => array('qr'),
+  );
+
+  $items['quant-clear-queue'] = array(
+    'callback' => 'drush_quant_clear_queue',
+    'description' => 'Reset the queue',
+    'arguments' => array(),
+    'options' => array(),
+    'aliases' => array('qr'),
   );
 
   return $items;
 }
 
 /**
- * Callback function to seed quant content via drush.
+ * Callback function to run a threaded seed process.
+ */
+function drush_quant_process_queue($threads=5) {
+  _validate_quant_config();
+
+  if (drush_get_option('threads')) {
+    $threads = drush_get_option('threads');
+  }
+
+  if (!intval($threads)) {
+    drush_log('Invalid thread specification (must be an integer).', 'error');
+  }
+
+  drush_log("Quant: Forking seed worker with $threads threads.", 'ok');
+  for ($i = 0; $i < $threads; $i++) {
+    $cmd = 'drush queue-run quant_seed';
+    $process = proc_open($cmd, [], $pipes, NULL, NULL, ['bypass_shell' => TRUE]);
+  }
+
+}
+
+/**
+ * Callback function to reset the queue.
+ */
+function drush_quant_clear_queue() {
+  $queue = quant_get_queue();
+  $queue->deleteQueue();
+  drush_log('Quant queue has been reset.', 'ok');
+}
+
+/**
+ * Callback function to populate the Quant queue via drush.
  */
 function drush_quant_seed() {
-  drush_log('Quant: Seed starting!', 'ok');
+  drush_log('Quant: Populating seed queue.', 'ok');
+  _validate_quant_config();
+  _quant_seed_prepare();
+}
 
+
+/**
+ * Validate Quant configuration prior to drush operation.
+ */
+function _validate_quant_config() {
   $token = variable_get('quant_api_token');
   $customer = variable_get('quant_api_customer');
   $project = variable_get('quant_api_project');
@@ -44,12 +101,5 @@ function drush_quant_seed() {
     drush_log('Quant API project is not configured', 'error');
   }
 
-  drush_log("Seeding for $customer: $project", 'ok');
-
-  _quant_seed_prepare();
-
-  $batch =& batch_get();
-  $batch['progressive'] = FALSE;
-
-  drush_backend_batch_process();
+  drush_log("Running Quant operation for $customer: $project", 'ok');
 }

--- a/quant.info
+++ b/quant.info
@@ -3,3 +3,4 @@ description = Quant content export
 package = Quant
 core = 7.x
 configure = admin/config/services/quant
+dependencies[] = quant:quant_api

--- a/quant.install
+++ b/quant.install
@@ -6,44 +6,21 @@
  */
 
 /**
- * Implements hook_quant_schema().
+ * Perform setup tasks.
  */
-function quant_schema() {
-  $schema['quant_token'] = array(
-    'description' => 'Short-lived access tokens for revisions.',
-    'fields' => array(
-      'pid' => array(
-        'type' => 'serial',
-        'not null' => TRUE,
-        'description' => 'Primary key: Unique token ID.',
-        'unsigned' => TRUE,
-      ),
-      'nid' => array(
-        'type' => 'int',
-        'unsigned' => TRUE,
-        'not null' => TRUE,
-        'default' => 0,
-        'description' => 'The node that is to be accessed.',
-      ),
-      'token' => array(
-        'type' => 'varchar',
-        'not null' => TRUE,
-        'length' => 255,
-        'default' => '',
-        'description' => 'The token value.',
-      ),
-      'created' => array(
-        'description' => 'The Unix timestamp when the token was created.',
-        'type' => 'int',
-        'not null' => TRUE,
-        'default' => 0,
-      ),
-    ),
-    'indexes' => array(
-      'token' => array('token'),
-    ),
-    'primary key' => array('pid'),
-  );
+function quant_install() {
+  // Prepare configuration for quant tokens.
+  variable_set('quant_token_secret', bin2hex(random_bytes(32)));
+  variable_set('quant_token_timeout', '+1 minute');
+}
 
-  return $schema;
+/**
+ * Remove the quant_token table.
+ */
+function quant_update_7000() {
+  if (db_table_exists('quant_token')) {
+    db_drop_table('quant_token');
+  }
+  variable_set('quant_token_secret', bin2hex(random_bytes(32)));
+  variable_set('quant_token_timeout', '+1 minute');
 }

--- a/quant.module
+++ b/quant.module
@@ -601,10 +601,11 @@ function _quant_prepare_entity($type, $entity_id) {
     return FALSE;
   }
 
-  switch($type) {
+  switch ($type) {
     case 'file':
       $url = file_create_url($entity->uri);
       break;
+
     default:
       $entity = reset($entity);
       $uri = entity_uri($type, $entity);
@@ -805,6 +806,7 @@ function quant_seed_taxonomy_batch($tid) {
  *   Return items or the queue instance.
  *
  * @return mixed
+ *   A queue instance or queue items.
  */
 function quant_get_queue($items = FALSE) {
   if ($items) {
@@ -831,7 +833,8 @@ function quant_queue_worker($data) {
   list($op, $args) = $data;
   if (is_callable($op)) {
     call_user_func_array($op, $args);
-  } else {
+  }
+  else {
     quant_log('Unsupported callback: [%op]', array('%op' => $op));
   }
 }
@@ -932,8 +935,12 @@ function quant_batch_process_queue($queue_name, &$context) {
   // each batch run we can continuously progress through the queue
   // until completed.
   if ($queue->numberOfItems() > 0) {
-    $context['message'] = t('Processed @i of @t', ['@i' => $context['sandbox']['progress'], '@t' => $context['sandbox']['total']]);
-    // This will cause the progress bar to hang at 90% if additional queue items are added during the run.
+    $context['message'] = t('Processed @i of @t', array(
+      '@i' => $context['sandbox']['progress'],
+      '@t' => $context['sandbox']['total'],
+    ));
+    // This will cause the progress bar to hang at 90% if additional
+    // queue items are added during the run.
     $context['finished'] = $context['sandbox']['progress'] / $context['sandbox']['total'] >= 1 ? 0.9 : $context['sandbox']['progress'] / $context['sandbox']['total'];
   }
 }

--- a/quant.module
+++ b/quant.module
@@ -87,6 +87,16 @@ function quant_menu() {
 }
 
 /**
+ * Implements hook_cron_queue_info().
+ */
+function quant_cron_queue_info() {
+  $queues['quant_seed'] = array(
+    'worker callback' => 'quant_queue_worker',
+  );
+  return $queues;
+}
+
+/**
  * Implements hook_menu_alter().
  *
  * We intercept the standard route wildcard argument loader
@@ -109,11 +119,10 @@ function quant_menu_alter(&$items) {
  * Implements hook_admin_paths().
  */
 function quant_admin_paths() {
-  return array(
-    'admin/quant/config' => TRUE,
-    'admin/quant/seed' => TRUE,
-    'node/%node/quant' => FALSE,
-  );
+  $paths['admin/config/services/quant'] = TRUE;
+  $paths['admin/config/services/quant/*'] = TRUE;
+  $paths['node/%node/quant'] = FALSE;
+  return $paths;
 }
 
 /**
@@ -352,13 +361,13 @@ function _quant_post_entity_op($entity_info) {
  *   The url to seed.
  * @param array $context
  *   The context of the seed, usually includes entity info.
- * @param array $batch_context
- *   The context of the batch process.
  */
-function quant_seed($url, array $context = array(), array $batch_context = array()) {
+function quant_seed($url, array $context = array()) {
   global $base_url;
+  $base = quant_get_base_url();
 
   $path = parse_url($url, PHP_URL_PATH);
+  $path = ltrim($path, '/');
 
   if (path_is_admin($path)) {
     quant_log('Skip: !path is an admin path', array('!path' => $path));
@@ -369,7 +378,7 @@ function quant_seed($url, array $context = array(), array $batch_context = array
 
   $options = array(
     'headers' => array(
-      'Host' => variable_get('quant_hostname', $base_url),
+      'Host' => variable_get('quant_hostname', parse_url($base_url, PHP_URL_HOST)),
       'User-Agent' => 'Quant (+http://quantcdn.io)',
     ),
   );
@@ -403,7 +412,6 @@ function quant_seed($url, array $context = array(), array $batch_context = array
     // Ensure internal redirects have their destination seeded.
     if (_is_url_internal($dest)) {
       $dest_path = parse_url($dest, PHP_URL_PATH);
-      $base = variable_get('quant_base_url', $base_url);
       quant_seed("{$base}{$dest_path}", array());
     }
     else {
@@ -428,28 +436,29 @@ function quant_seed($url, array $context = array(), array $batch_context = array
 
   $markup = $response->data;
 
-  // Parse pages from Views and Taxonomy entities.
-  if (isset($context['find_pager']) && $context['find_pager']) {
+  $queue = quant_get_queue();
 
-    $document = new \DOMDocument();
-    @$document->loadHTML($markup);
-    $xpath = new \DOMXPath($document);
+  $document = new \DOMDocument();
+  @$document->loadHTML($markup);
+  $xpath = new \DOMXPath($document);
+  $page_urls = isset($context['page_urls']) ? $context['page_urls'] : [];
 
-    /** @var \DOMElement $node */
-    $pager_operations = [];
-    $page_urls = isset($context['page_urls']) ? $context['page_urls'] : [];
-    foreach ($xpath->query('//a[contains(@href,"page=") and contains(text(), "next")]') as $node) {
+  $pager_xpath = array(
+    '//a[contains(@href,"page=") and contains(text(), "next")]',
+    '//a[starts-with(@href, "/") and contains(text(), "first")]',
+  );
 
-      $original_href = $node->getAttribute('href');
+  if (variable_get('quant_pager_xpath')) {
+    $pager_xpath = explode(PHP_EOL, variable_get('quant_pager_xpath'));
+  }
+
+  foreach ($pager_xpath as $xpath_query) {
+    foreach ($xpath->query($xpath_query) as $node) {
+      $original_href = $new_href = $node->getAttribute('href');
       if ($original_href[0] === '?') {
         $new_href = strtok($path, '?') . $original_href;
       }
-      else {
-        $new_href = $original_href;
-      }
 
-      global $base_url;
-      $base = variable_get('quant_base_url', $base_url);
       $pager_url = $base . $new_href;
 
       if (in_array($pager_url, $page_urls)) {
@@ -457,28 +466,14 @@ function quant_seed($url, array $context = array(), array $batch_context = array
       }
 
       $page_urls[] = $pager_url;
-      $pager_operations[] = array(
-        'quant_seed',
-        array($pager_url, [
-          'find_pager' => TRUE,
-          'type' => 'view',
-          'page_urls' => $page_urls,
-        ],
-        ),
+      $next_context = array(
+        'find_pager' => TRUE,
+        'type' => 'view',
+        'page_urls' => $page_urls,
       );
-
+      $item = array('quant_seed', array($pager_url, $next_context));
+      $queue->createItem($item);
     }
-
-    $b = array(
-      'title' => t('Seeding views (Pages)'),
-      'operations' => $pager_operations,
-      'finished' => '_quant_batch_complete',
-      'init_message' => t('Initialising...'),
-      'progress_message' => t('Exporting views page @current out of @total'),
-      'error_message' => t('Unable to export'),
-      'file' => drupal_get_path('module', 'quant') . 'quant.module',
-    );
-    batch_set($b);
   }
 
   // Rewrite absolute URLs if relevant.
@@ -599,28 +594,28 @@ function _quant_prepare_entity($type, $entity_id) {
 
   list($id, $vid) = entity_extract_ids($type, $entity);
 
-  return [
+  return array(
     "$base/$alias",
-    [
+    array(
       'entity' => $entity,
       'vid' => $vid,
       'id' => $id,
       'type' => $type,
-    ],
-  ];
+    ),
+  );
 }
 
 /**
  * Prepare a batch process for the node entity type.
  *
- * @param array $batch
- *   The batch array.
  * @param array $bundles
  *   Optionally filter by node bundles.
  */
-function _quant_batch_nodes(array &$batch, array $bundles = array()) {
+function _quant_queue_nodes(array $bundles = array()) {
   global $base_url;
   $base = variable_get('quant_base_url', $base_url);
+
+  $queue = quant_get_queue();
 
   $query = db_select('node', 'n')
     ->fields('n', array('nid'))
@@ -630,33 +625,29 @@ function _quant_batch_nodes(array &$batch, array $bundles = array()) {
     $query->condition('n.type', array_keys($bundles), 'IN');
   }
 
-  $nids = $query
-    ->execute()
-    ->fetchCol();
+  $nids = $query->execute()->fetchCol();
 
-  // Add the homepage to the operations.
-  $batch['operations'][] = array('quant_seed', array("$base/", array()));
+  $item = array('quant_seed', array("$base/"));
+  $queue->createItem($item);
 
   foreach ($nids as $nid) {
     quant_log('Adding [!nid] to the list.', array('!nid' => $nid));
-    $batch['operations'][] = array(
+    $item = array(
       'quant_seed_node_batch',
       array($nid),
     );
+    $queue->createItem($item);
   }
-
-  return $batch;
 }
 
 /**
  * Prepare a batch process for taxonomy entities.
- *
- * @param array $batch
- *   The batch array.
  */
-function _quant_batch_taxonomy(array &$batch) {
+function _quant_queue_taxonomy() {
   global $base_url;
   $base = variable_get('quant_base_url', $base_url);
+
+  $queue = quant_get_queue();
 
   // @todo: Support select vocabs.
   $tids = db_select('taxonomy_term_data', 't')
@@ -666,26 +657,22 @@ function _quant_batch_taxonomy(array &$batch) {
 
   foreach ($tids as $tid) {
     quant_log('Adding [!tid] to the list.', array('!tid' => $tid));
-    $batch['operations'][] = array(
+    $item = array(
       'quant_seed_taxonomy_batch',
       array($tid),
     );
+    $queue->createItem($item);
   }
-
-  return $batch;
-
 }
 
 /**
  * Prepare the images to seed via batch.
- *
- * @param array $batch
- *   The batch array.
  */
-function _quant_batch_images(array &$batch) {
+function _quant_batch_images() {
   $theme_dir = drupal_get_path('theme', variable_get('theme_default', NULL));
-
   $files = file_scan_directory(DRUPAL_ROOT . "/$theme_dir", QUANT_THEME_FILE_MASK);
+
+  $queue = quant_get_queue();
 
   // Allow modules to provide some files if they need to.
   drupal_alter('quant_seed_files', $file);
@@ -700,22 +687,22 @@ function _quant_batch_images(array &$batch) {
 
     quant_log('Preparing !path', array('!path' => $path));
 
-    $batch['operations'][] = array(
+    $item = array(
       'quant_seed_file',
       array($path, $context),
     );
+    $queue->createItem($item);
   }
 }
 
 /**
  * Get a list of views paths.
- *
- * @param array $batch
- *   The batch array.
  */
-function _quant_batch_views(array &$batch) {
+function _quant_queue_views() {
   global $base_url;
   $base = variable_get('quant_base_url', $base_url);
+
+  $queue = quant_get_queue();
 
   $menus = array();
 
@@ -732,26 +719,26 @@ function _quant_batch_views(array &$batch) {
     // @TODO: We have menu access callbacks so we should
     // validate anonymous has access before we add the operation.
     // Pages will be exported to quant with 401.
-    $batch['operations'][] = array(
+    $item = array(
       'quant_seed',
       array($url, $config),
     );
+    $queue->createItem($item);
   }
 }
 
 /**
  * Generate a batch of arbitrary routes.
  *
- * @param array $batch
- *   The batch array.
  * @param string $routes
  *   Textarea entered routes.
  */
-function _quant_batch_routes(array &$batch, $routes) {
+function _quant_queue_routes($routes) {
   global $base_url;
   $base = variable_get('quant_base_url', $base_url);
-
   $routes = is_array($routes) ? $routes : explode(PHP_EOL, $routes);
+
+  $queue = quant_get_queue();
 
   foreach ($routes as $route) {
     if (strpos((trim($route)), '/') !== 0) {
@@ -760,15 +747,16 @@ function _quant_batch_routes(array &$batch, $routes) {
 
     $url = $base . $route;
 
-    $batch['operations'][] = array(
+    $item = array(
       'quant_seed',
       array(trim($url)),
     );
+    $queue->createItem($item);
   }
 }
 
 /**
- * Batch processor for exporting nodes.
+ * Expensive node preparation to begin the seed.
  */
 function quant_seed_node_batch($nid) {
   list($url, $context) = _quant_prepare_entity('node', $nid);
@@ -789,6 +777,29 @@ function quant_seed_taxonomy_batch($tid) {
 }
 
 /**
+ * Generate the quant_seed queue.
+ *
+ * @return SystemQueue
+ */
+function quant_get_queue() {
+  $queue = DrupalQueue::get('quant_seed');
+  $queue->createQueue();
+  return $queue;
+}
+
+/**
+ * Process the queue.
+ */
+function quant_queue_worker($data) {
+  list($op, $args) = $data;
+  if (is_callable($op)) {
+    call_user_func_array($op, $args);
+  } else {
+    quant_log('Unsupported callback: [%op]', array('%op' => $op));
+  }
+}
+
+/**
  * Create the batch process to export the form.
  *
  * @param array $form
@@ -797,9 +808,50 @@ function quant_seed_taxonomy_batch($tid) {
  *   The submitted form values.
  */
 function _quant_seed_prepare(array $form = array(), array $form_state = array()) {
-  if (!empty($form_state['values']) && $form_state['values']['quant_seed'] == 0) {
-    drupal_set_message('Quant: Skipping the batch process.', 'warning');
-    return [];
+  $queue = quant_get_queue();
+
+  // Reset the queue whenever we want to fully prepare a seed.
+  $queue->deleteQueue();
+  $queue->createQueue();
+
+  if (variable_get('quant_seed_entity_node')) {
+    $node_bundles = array_filter(variable_get('quant_seed_entity_node_bundles'));
+    _quant_queue_nodes($node_bundles);
+  }
+
+  if (variable_get('quant_seed_entity_taxonomy')) {
+    _quant_queue_taxonomy();
+  }
+
+  if (variable_get('quant_seed_theme_assets')) {
+    _quant_batch_images();
+  }
+
+  if (variable_get('quant_seed_views')) {
+    _quant_queue_views();
+  }
+
+  $routes = array('/_quant404');
+
+  if (variable_get('quant_custom_routes')) {
+    $routes = array_merge($routes, variable_get('quant_custom_routes'));
+  }
+
+  if (variable_get('quant_robots')) {
+    $routes[] = '/robots.txt';
+  }
+
+  _quant_queue_routes($routes);
+
+  module_invoke_all('quant_seed_queue');
+}
+
+/**
+ * Process the queue inline with a Drupal batch process.
+ */
+function _quant_queue_batch() {
+  if (!variable_get('trigger_quant_seed')) {
+    return;
   }
 
   $batch = array(
@@ -812,39 +864,41 @@ function _quant_seed_prepare(array $form = array(), array $form_state = array())
     'file' => drupal_get_path('module', 'quant') . 'quant.module',
   );
 
-  $node_bundles = array_filter(variable_get('quant_seed_entity_node_bundles'));
-  if (variable_get('quant_seed_entity_node')) {
-    _quant_batch_nodes($batch, $node_bundles);
-  }
-
-  if (variable_get('quant_seed_entity_taxonomy')) {
-    _quant_batch_taxonomy($batch);
-  }
-
-  if (variable_get('quant_seed_theme_assets')) {
-    _quant_batch_images($batch);
-  }
-
-  if (variable_get('quant_seed_views')) {
-    _quant_batch_views($batch);
-  }
-
-  if (variable_get('quant_custom_routes')) {
-    _quant_batch_routes($batch, variable_get('quant_custom_routes'));
-  }
-
-  if (variable_get('quant_robots')) {
-    _quant_batch_routes($batch, array('/robots.txt'));
-  }
-
-  // Allow module to alter the operation.
-  drupal_alter('quant_seed', $batch);
-
-  quant_log('Total operations [!total]', array(
-    '!total' => count($batch['operations']),
-  ));
+  $batch['operations'][] = array('quant_batch_process_queue', array('quant_seed'));
 
   batch_set($batch);
+}
+
+/**
+ * Batch handler to process the quant seed queue.
+ */
+function quant_batch_process_queue($queue_name, &$context) {
+  $queue = DrupalQueue::get($queue_name);
+  $queue->createQueue();
+  $item = $queue->claimItem();
+
+  if (empty($context['sandbox']['progress'])) {
+    $context['sandbox']['progress'] = 0;
+    $context['sandbox']['total'] = $queue->numberOfItems();
+  }
+
+  if (!$item) {
+    $context['finished'] = 1;
+    return FALSE;
+  }
+
+  quant_queue_worker($item->data);
+  $queue->deleteItem($item);
+  $context['sandbox']['progress']++;
+
+  // Callbacks can add additional items to the queue, by setting this
+  // each batch run we can continuously progress through the queue
+  // until completed.
+  if ($queue->numberOfItems() > 0) {
+    $context['message'] = t('Processed @i of @t', ['@i' => $context['sandbox']['progress'], '@t' => $context['sandbox']['total']]);
+    // This will cause the progress bar to hang at 90% if additional queue items are added during the run.
+    $context['finished'] = $context['sandbox']['progress'] / $context['sandbox']['total'] >= 1 ? 0.9 : $context['sandbox']['progress'] / $context['sandbox']['total'];
+  }
 }
 
 /**
@@ -945,9 +999,11 @@ function quant_token_validate($nid, $strict = TRUE) {
     return FALSE;
   }
 
+  $token = _quant_get_request_header('quant-token');
+
   $record = db_select('quant_token', 'qt')
     ->fields('qt', ['nid', 'created'])
-    ->condition('token', $headers['quant-token'])
+    ->condition('token', $token)
     ->execute()
     ->fetchAssoc();
 
@@ -1075,4 +1131,16 @@ function _quant_get_request_header($header) {
     }
   }
   return FALSE;
+}
+
+/**
+ * Get the quant configured base URL.
+ *
+ * @return string
+ *   The base URL.
+ */
+function quant_get_base_url() {
+  global $base_url;
+  $base = variable_get('quant_base_url', $base_url);
+  return $base;
 }

--- a/quant.module
+++ b/quant.module
@@ -413,9 +413,6 @@ function quant_seed($url, array $context = array()) {
     $options['headers']['quant-revision'] = $context['vid'];
   }
 
-  dpm($options);
-  return;
-
   $response = drupal_http_request($url, $options);
 
   // Add a redirect if 301|302.

--- a/quant.module
+++ b/quant.module
@@ -10,7 +10,7 @@
  *
  * @var string
  */
-define('QUANT_THEME_FILE_MASK', '/^.+(.jpe?g|.png|.svg|.ttf|.woff|.woff2|.otf)$/i');
+define('QUANT_THEME_FILE_MASK', '/^.+(.jpe?g|.png|.svg|.ttf|.woff|.woff2|.otf|.css|.js)$/i');
 
 /**
  * Quant verbose logging.
@@ -397,7 +397,7 @@ function quant_seed($url, array $context = array()) {
     return;
   }
 
-  quant_log('Preparing to send !url', array('!url' => $url));
+  quant_log('Sending content: !url', array('!url' => $url));
 
   $options = array(
     'headers' => array(
@@ -415,6 +415,43 @@ function quant_seed($url, array $context = array()) {
 
   $response = drupal_http_request($url, $options);
 
+  // Ensure file entities have their underlying asset seeded.
+  if (isset($context['type']) && $context['type'] == 'file') {
+
+    // Public file handler
+    if(strpos($context['entity']->uri, "public://" ) === 0) {
+
+      // Seed the underlying file to the web-accessible public files path.
+      $file_on_disk = drupal_realpath($context['entity']->uri);
+
+      // File exists in filesystem.
+      if (!empty($file_on_disk)) {
+
+        $public_path = $file_on_disk;
+        if (substr($file_on_disk, 0, strlen(DRUPAL_ROOT)) == DRUPAL_ROOT) {
+          $public_path = substr($file_on_disk, strlen(DRUPAL_ROOT));
+        }
+
+        // Create a redirect from file download uri location to public file path.
+        if (module_exists('quant_redirect')) {
+          $download_uri = file_entity_download_uri($context['entity']);
+          $download_path = url($download_uri['path'], $download_uri['options']);
+
+          // We purposefully exclude the token from file paths.
+          $download_path = parse_url($download_path, PHP_URL_PATH);
+          quant_redirect_request($download_path, $public_path, 301);
+        }
+
+        $fileCtx = array(
+          'location' => $context['entity']->uri,
+          'request' => $public_path,
+        );
+
+        quant_seed_file("{$base}{$public_path}", $fileCtx);
+      }
+    }
+  }
+
   // Add a redirect if 301|302.
   if (isset($response->redirect_code) && ($response->redirect_code == 301 || $response->redirect_code == 302)) {
     // Strip quant params from destination.
@@ -429,13 +466,22 @@ function quant_seed($url, array $context = array()) {
 
     // Ensure internal redirects have their destination seeded.
     if (_is_url_internal($dest)) {
+
       $dest_path = parse_url($dest, PHP_URL_PATH);
-      quant_seed("{$base}{$dest_path}", array());
+
+      if (isset($context['type']) && $context['type'] == 'file') {
+        // File asset already handled.
+        return;
+      }
+      else {
+        quant_seed("{$base}{$dest_path}", array());
+      }
     }
-    else {
-      return;
-    }
+
+    // Redirect created, internal redirect followed + seeded.
+    return;
   }
+
 
   if (($response->code == 404 || $response->code == 403) && strpos($url, '/_quant404') === FALSE) {
     // Ensure that the route is not accessible in Quant.
@@ -623,7 +669,10 @@ function _quant_prepare_entity($type, $entity_id) {
 
   switch ($type) {
     case 'file':
-      $url = file_create_url($entity->uri);
+      $uri = entity_uri($type, $entity);
+      $path = $uri['path'];
+      $alias = drupal_get_path_alias($path);
+      $url = "$base/$alias";
       break;
 
     default:
@@ -710,7 +759,7 @@ function _quant_queue_taxonomy() {
 /**
  * Prepare the images to seed via batch.
  */
-function _quant_queue_images() {
+function _quant_queue_theme_assets() {
   $theme_dir = drupal_get_path('theme', variable_get('theme_default', NULL));
   $files = file_scan_directory(DRUPAL_ROOT . "/$theme_dir", QUANT_THEME_FILE_MASK);
 
@@ -720,18 +769,22 @@ function _quant_queue_images() {
   drupal_alter('quant_seed_files', $file);
 
   foreach ($files as $file) {
-    $path = urldecode($file->uri);
+
+    $file_on_disk = $file->uri;
+    if (substr($file_on_disk, 0, strlen(DRUPAL_ROOT)) == DRUPAL_ROOT) {
+      $file_on_disk = substr($file_on_disk, strlen(DRUPAL_ROOT));
+    }
 
     $context = array(
       'location' => $file->uri,
-      'request' => str_replace(DRUPAL_ROOT, '', $file->uri),
+      'request' => $file_on_disk,
     );
 
-    quant_log('Preparing !path', array('!path' => $path));
+    quant_log('Preparing !path', array('!path' => $file_on_disk));
 
     $item = array(
       'quant_seed_file',
-      array($path, $context),
+      array($file_on_disk, $context),
     );
     $queue->createItem($item);
   }
@@ -885,7 +938,7 @@ function _quant_seed_prepare(array $form = array(), array $form_state = array())
   }
 
   if (variable_get('quant_seed_theme_assets')) {
-    _quant_queue_images();
+    _quant_queue_theme_assets();
   }
 
   if (variable_get('quant_seed_views')) {

--- a/quant.module
+++ b/quant.module
@@ -865,6 +865,8 @@ function _quant_seed_prepare(array $form = array(), array $form_state = array())
   $queue->deleteQueue();
   $queue->createQueue();
 
+  $routes = array();
+
   if (variable_get('quant_seed_entity_node')) {
     $node_bundles = array_filter(variable_get('quant_seed_entity_node_bundles'));
     _quant_queue_nodes($node_bundles);
@@ -884,8 +886,13 @@ function _quant_seed_prepare(array $form = array(), array $form_state = array())
 
   $routes = array('/_quant404');
 
-  if (variable_get('quant_custom_routes')) {
-    $routes = array_merge($routes, variable_get('quant_custom_routes'));
+  if (variable_get('quant_custom_routes_enabled')) {
+    foreach (explode(PHP_EOL, variable_get('quant_custom_routes')) as $route) {
+      if (strpos((trim($route)), '/') !== 0) {
+        continue;
+      }
+      $routes[] = trim($route);
+    }
   }
 
   if (variable_get('quant_robots')) {
@@ -904,6 +911,8 @@ function _quant_queue_batch() {
   if (!variable_get('trigger_quant_seed')) {
     return;
   }
+
+  _quant_seed_prepare();
 
   $batch = array(
     'title' => t('Quant seeding'),

--- a/quant.module
+++ b/quant.module
@@ -1140,10 +1140,13 @@ function quant_token_validate($route, $strict = TRUE) {
     return FALSE;
   }
 
-  if ($strict && (parse_url($route, PHP_URL_PATH) != parse_url($payload['route'], PHP_URL_PATH))) {
-    watchdog('quant_token', 'Strict token mismatch: Expected [@path] Received [@route]', array(
-      '@path' => parse_url($payload['route'], PHP_URL_PATH),
-      '@route' => parse_url($route, PHP_URL_PATH),
+  $expected_route = parse_url(ltrim($route, '/'));
+  $received_route = parse_url(ltrim($payload['route'], '/'));
+
+  if ($strict && $expected_route != $received_route) {
+    watchdog('quant_token', 'Strict token mismatch: Expected [@expected] Received [@received]', array(
+      '@expected' => $expected_route,
+      '@received' => $received_route,
     ), WATCHDOG_INFO);
     return FALSE;
   }

--- a/quant.module
+++ b/quant.module
@@ -607,7 +607,6 @@ function _quant_prepare_entity($type, $entity_id) {
       break;
 
     default:
-      $entity = reset($entity);
       $uri = entity_uri($type, $entity);
       $path = $uri['path'];
       $alias = drupal_get_path_alias($path);

--- a/quant.module
+++ b/quant.module
@@ -18,13 +18,6 @@ define('QUANT_THEME_FILE_MASK', '/^.+(.jpe?g|.png|.svg|.ttf|.woff|.woff2|.otf)$/
 define('QUANT_VERBOSE', 'verbose');
 
 /**
- * The elapsed time a short-live token can be alive for.
- *
- * @var string
- */
-define('QUANT_ELAPSED_TIME', '+1 minute');
-
-/**
  * Implements hook_help().
  */
 function quant_help($section) {
@@ -83,6 +76,17 @@ function quant_menu() {
     'weight' => 10,
   );
 
+  $items['admin/config/services/quant/token'] = array(
+    'title' => 'Token',
+    'description' => 'Configure the Quant internal token system',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('quant_token_settings'),
+    'file' => 'quant.admin.inc',
+    'access arguments' => array('configure quant'),
+    'type' => MENU_LOCAL_TASK,
+    'weight' => 3
+  );
+
   // Custom quant view controller.
   $items['node/%node/quant'] = array(
     'title callback' => 'quant_page_title',
@@ -115,7 +119,6 @@ function quant_cron_queue_info() {
  * standard router context continue to operate as expected.
  */
 function quant_menu_alter(&$items) {
-
   // Altering the node route breaks displaysuite.
   if (variable_get('disable_content_drafts', FALSE)) {
     return;
@@ -191,32 +194,40 @@ function quant_cron() {
   db_query('TRUNCATE {quant_token}');
 }
 
+function quant_forbidden() {
+  http_response_code(403);
+  die('Forbidden');
+}
+
+
 /**
- * Implements hook_node_access().
+ * Implements hook_init().
  *
- * This is not called for all users - if a user has the 'bypass node access'
- * permission this will not be called (eg. uid 1).
- *
- * Additionally 'access content' needs to be given to anonymous for this to
- * take effect.
- *
- * @see node_access
+ * Perform token validation at the beginning of the request. This allows us to
+ * generate a token for the request and then embed resources into the page without
+ * clashing with node_access restrictions.
  */
-function quant_node_access($node, $op, $account) {
-
-  if (is_string($node)) {
-    return NODE_ACCESS_IGNORE;
+function quant_init() {
+  if (empty(_quant_get_request_header('quant-token'))) {
+    // Skip token checking if we don't have a token - this will
+    // allow the site to operate correctly in normal browsing
+    // patterns.
+    return;
   }
 
-  if (variable_get('disable_content_drafts', FALSE)) {
-    return NODE_ACCESS_IGNORE;
+  $path = current_path();
+  $path_alias = drupal_lookup_path('alias', $path);
+  $strict = variable_get('quant_token_strict', true);
+
+  if (quant_token_validate($path_alias, $strict)) {
+    return;
   }
 
-  if (!empty(_quant_get_request_header('quant-token'))) {
-    return quant_token_validate($node->nid) ? NODE_ACCESS_ALLOW : NODE_ACCESS_DENY;
+  if (quant_token_validate($path, $strict)) {
+    return;
   }
 
-  return NODE_ACCESS_IGNORE;
+  quant_forbidden();
 }
 
 /**
@@ -226,8 +237,10 @@ function quant_node_load($nodes) {
   if (empty(_quant_get_request_header('quant-token'))) {
     return;
   }
+
   foreach ($nodes as $node) {
-    if (quant_token_validate($node->nid)) {
+    $path = drupal_lookup_path('alias', "node/{$node->nid}");
+    if (quant_token_validate($path, FALSE)) {
       $node->status = 1;
     }
   }
@@ -393,17 +406,15 @@ function quant_seed($url, array $context = array()) {
     ),
   );
 
-  if (isset($context['token'])) {
-    $options['headers']['quant-token'] = $context['token'];
-  }
-  elseif (isset($context['id'])) {
-    // Create a short-lived token to grant node access.
-    $options['headers']['quant-token'] = quant_token_create($context['id']);
-  }
+  // Ensure Quant internal requests are signed.
+  $options['headers']['quant-token'] = quant_token_create($url);
 
   if (isset($context['vid']) && $context['type'] == 'node') {
     $options['headers']['quant-revision'] = $context['vid'];
   }
+
+  dpm($options);
+  return;
 
   $response = drupal_http_request($url, $options);
 
@@ -1016,39 +1027,68 @@ function quant_export_drupal_pages() {
 }
 
 /**
+ * Prepare a JWT header part.
+ *
+ * @param array|string $part
+ *   The part to encode.
+ *
+ * @return string
+ *   base64encoded string.
+ */
+function quant_jwt_encode($part = []) {
+  if (is_array($part)) {
+    $part = json_encode($part);
+  }
+  $encoded = base64_encode($part);
+
+  if ($encoded === FALSE) {
+    throw new \Exception('Unable to encode part.');
+  }
+
+  $encoded = strtr($encoded, '+/', '-_');
+  return rtrim($encoded, '=');
+}
+
+/**
+ * Reverse the JWT encode.
+ *
+ * @param string $string
+ *   The encoded string.
+ * @param bool $strict
+ *   Base64 in strict mode.
+ *
+ * @return string|array
+ *   The decoded URL part.
+ */
+function quant_jwt_decode($string, $strict = FALSE) {
+    $string = strtr($string, '-_', '+/');
+    $part = base64_decode($string, $strict);
+    $array_part = json_decode($part, TRUE);
+    return empty($array_part) ? $part : $array_part;
+  }
+
+/**
  * Add a short-lived token to the table.
  *
  * @return string
  *   The generated token.
  */
-function quant_token_create($nid) {
-  // This is slightly different to the D8 implementation
-  // openssl produces different characters that get_query_parameters
-  // cannot handle correctly so we just use random bytes.
-  if (function_exists('random_bytes')) {
-    $bytes = random_bytes(ceil(16 / 2));
-    $token = substr(bin2hex($bytes), 0, 16);
-  }
-  else {
-    $token = bin2hex(random_bytes(16));
-  }
+function quant_token_create($route) {
+  $secret = variable_get('quant_token_secret', 'supersecret');
+  $time = new DateTime(variable_get('quant_token_timeout', '+1 minute'));
 
-  $token = base64_encode($token);
+  $header = ['typ' => 'JWT', 'alg' => 'HS256'];
+  $payload = [
+    'user' => 'quant',
+    'route' => PARSE_URL($route, PHP_URL_PATH),
+    'expires' => $time->format('U'),
+  ];
 
-  try {
-    db_insert('quant_token')
-      ->fields(array(
-        'token' => $token,
-        'nid' => $nid,
-        'created' => REQUEST_TIME,
-      ))
-      ->execute();
-  }
-  catch (\Exception $error) {
-    var_dump($error->getMessage());
-  }
+  $header = quant_jwt_encode($header);
+  $payload = quant_jwt_encode($payload);
+  $signature = hash_hmac('sha256', "$header.$payload", $secret, TRUE);
 
-  return $token;
+  return "$header.$payload." . quant_jwt_encode($signature);
 }
 
 /**
@@ -1057,31 +1097,61 @@ function quant_token_create($nid) {
  * @return bool
  *   If the token is valid.
  */
-function quant_token_validate($nid, $strict = TRUE) {
-
-  if (empty(_quant_get_request_header('quant-token'))) {
-    return FALSE;
-  }
-
+function quant_token_validate($route, $strict = TRUE) {
   $token = _quant_get_request_header('quant-token');
+  $secret = variable_get('quant_token_secret', 'supersecret');
+  $current_time = new DateTime;
 
-  $record = db_select('quant_token', 'qt')
-    ->fields('qt', ['nid', 'created'])
-    ->condition('token', $token)
-    ->execute()
-    ->fetchAssoc();
-
-  if (empty($record) || empty($record['created']) || empty($record['nid'])) {
-    // Something went wrong, we don't have the fields we need.
-    return FALSE;
-  }
-
-  if (!$strict) {
+  if (variable_get('quant_token_disable', FALSE)) {
+    // If token validation is disabled we assume the user has access
+    // to the request.
     return TRUE;
   }
 
-  $valid_until = strtotime(QUANT_ELAPSED_TIME, $record['created']);
-  return REQUEST_TIME < $valid_until && $nid == $record['nid'];
+  if (empty($token)) {
+    return FALSE;
+  }
+
+  $token_parts = explode('.', $token);
+  $header = quant_jwt_decode($token_parts[0]);
+  $payload = quant_jwt_decode($token_parts[1]);
+
+  $provided_signature = $token_parts[2];
+
+  $signature = hash_hmac('sha256', "{$token_parts[0]}.{$token_parts[1]}", $secret, TRUE);
+  $signature = quant_jwt_encode($signature);
+
+  if ($signature !== $provided_signature || empty($payload['expires'])) {
+    watchdog('quant_token', 'Invalid token [@token]', array('@token' => $token), WATCHDOG_INFO);
+    return FALSE;
+  }
+
+  $request_time = new DateTime();
+  $request_time->setTimestamp($payload['expires']);
+  $date_diff = $current_time->diff($request_time);
+
+  // The %r format will return empty string or '-' if the diff is
+  // in the past, we can use this to determine if the date diff
+  // is negative and restrict access accordingly.
+  // @see https://www.php.net/manual/en/dateinterval.format.php
+  if (!empty($date_diff->format('%r'))) {
+    watchdog('quant_token', 'Expired token: Expected [@time] Received [@cur_time] (@diff)', array(
+      '@time' => $request_time->format('d/m/y H:m:s'),
+      '@cur_time' => $current_time->format('d/m/y H:m:s'),
+      '@diff' => $date_diff->format('%r'),
+    ), WATCHDOG_INFO);
+    return FALSE;
+  }
+
+  if ($strict && (parse_url($route, PHP_URL_PATH) != parse_url($payload['route'], PHP_URL_PATH))) {
+    watchdog('quant_token', 'Strict token mismatch: Expected [@path] Received [@route]', array(
+      '@path' => parse_url($payload['route'], PHP_URL_PATH),
+      '@route' => parse_url($route, PHP_URL_PATH),
+    ), WATCHDOG_INFO);
+    return FALSE;
+  }
+
+  return TRUE;
 }
 
 /**

--- a/quant.module
+++ b/quant.module
@@ -73,6 +73,16 @@ function quant_menu() {
     'weight' => 1,
   );
 
+  $items['admin/config/services/quant/queue'] = array(
+    'title' => 'Queue',
+    'description' => 'Prepared items ready to be sent to quant.',
+    'page callback' => 'quant_queue_page',
+    'file' => 'quant.admin.inc',
+    'access arguments' => array('configure quant'),
+    'type' => MENU_LOCAL_TASK,
+    'weight' => 10,
+  );
+
   // Custom quant view controller.
   $items['node/%node/quant'] = array(
     'title callback' => 'quant_page_title',
@@ -583,19 +593,31 @@ function _quant_prepare_entity($type, $entity_id) {
   $base = variable_get('quant_base_url', $base_url);
   $entity = entity_load($type, [$entity_id]);
 
+  if (is_array($entity)) {
+    $entity = reset($entity);
+  }
+
   if (empty($entity)) {
     return FALSE;
   }
 
-  $entity = reset($entity);
-  $uri = entity_uri($type, $entity);
-  $path = $uri['path'];
-  $alias = drupal_get_path_alias($path);
+  switch($type) {
+    case 'file':
+      $url = file_create_url($entity->uri);
+      break;
+    default:
+      $entity = reset($entity);
+      $uri = entity_uri($type, $entity);
+      $path = $uri['path'];
+      $alias = drupal_get_path_alias($path);
+      $url = "$base/$alias";
+      break;
+  }
 
   list($id, $vid) = entity_extract_ids($type, $entity);
 
   return array(
-    "$base/$alias",
+    $url,
     array(
       'entity' => $entity,
       'vid' => $vid,
@@ -668,7 +690,7 @@ function _quant_queue_taxonomy() {
 /**
  * Prepare the images to seed via batch.
  */
-function _quant_batch_images() {
+function _quant_queue_images() {
   $theme_dir = drupal_get_path('theme', variable_get('theme_default', NULL));
   $files = file_scan_directory(DRUPAL_ROOT . "/$theme_dir", QUANT_THEME_FILE_MASK);
 
@@ -779,9 +801,24 @@ function quant_seed_taxonomy_batch($tid) {
 /**
  * Generate the quant_seed queue.
  *
- * @return SystemQueue
+ * @param bool $items
+ *   Return items or the queue instance.
+ *
+ * @return mixed
  */
-function quant_get_queue() {
+function quant_get_queue($items = FALSE) {
+  if ($items) {
+    $items = array();
+    $query = db_select('queue', 'q')->extend('PagerDefault');
+    $query->condition('name', 'quant_seed')
+      ->fields('q', array('item_id', 'data', 'expire', 'created'));
+    $result = $query->limit(10)->orderBy('q.item_id')->execute();
+    foreach ($result as $item) {
+      $items[] = (array) $item;
+    }
+    return $items;
+  }
+
   $queue = DrupalQueue::get('quant_seed');
   $queue->createQueue();
   return $queue;
@@ -824,7 +861,7 @@ function _quant_seed_prepare(array $form = array(), array $form_state = array())
   }
 
   if (variable_get('quant_seed_theme_assets')) {
-    _quant_batch_images();
+    _quant_queue_images();
   }
 
   if (variable_get('quant_seed_views')) {


### PR DESCRIPTION
- Updates the quant API to leverage the core queue API rather than batch for concurrent seeds
- Adds a UI option to view items in the queue
- Adds a batch handler to process the queue inline if required (eg. small sites)
- Concurrent queue runs can be scheduled via standard drush mechanisms
- Queue entries will be processed via a worker that can be scheduled with cron
- Updates drupal_alter to module_invoke_all and changed api.inc accordingly
- Updates submodules to use the new API (queues > batch)

Some bug fixes:

- Fixed a bug with identifying file URIs (they would always return as the seed URL)
- Fixed a bug with quant configuration paths not being identified as admin
- Fixed a bug with retrieving quant headers for internal requests

![image](https://user-images.githubusercontent.com/1840912/96459703-befa3e80-1265-11eb-8b5c-ecc4aeeab61b.png)
