### PR TITLE
Change date generation for tokens.

### DIFF
--- a/quant.module
+++ b/quant.module
@@ -11,6 +11,8 @@ use Drupal\node\NodeInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
+use Drupal\quant\Exception\ExpiredTokenException;
+use Drupal\quant\Exception\InvalidTokenException;
 use Drupal\quant\Plugin\QueueItem\RouteItem;
 use Drupal\quant\Seed;
 use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
@@ -175,18 +177,28 @@ function quant_node_access(NodeInterface $node, $op, AccountInterface $account) 
   $options = ['absolute' => FALSE];
   $url = Url::fromRoute('entity.node.canonical', ['node' => $node->id()], $options)->toString();
 
-  if (\Drupal::service('quant.token_manager')->validate($url, FALSE)) {
-    // Node access override only applies to the currently viewed node.
-    $routeNode = \Drupal::routeMatch()->getParameter('node');
-    $nid = $routeNode->id();
-    if ($nid == $node->id()) {
-      return AccessResult::allowed();
-    }
+  try {
+    \Drupal::service('quant.token_manager')->validate($url, FALSE);
+  }
+  catch (ExpiredTokenException $e) {
+    throw new ServiceUnavailableHttpException(3600, t('Service route is not available.'));
 
-    return AccessResult::neutral();
+  }
+  catch (InvalidTokenException $e) {
+    throw new ServiceUnavailableHttpException(3600, t('Service route is not available.'));
   }
 
-  throw new ServiceUnavailableHttpException(3600, t('Service route is not available.'));
+  // If the token validation didn't trigger an exception - then the
+  // token is valid and can be continued to be evaluated to allow
+  // access to the node.
+  $routeNode = \Drupal::routeMatch()->getParameter('node');
+  $nid = $routeNode->id();
+
+  if ($nid == $node->id()) {
+    return AccessResult::allowed();
+  }
+
+  return AccessResult::neutral();
 }
 
 /**

--- a/quant.module
+++ b/quant.module
@@ -178,7 +178,7 @@ function quant_node_access(NodeInterface $node, $op, AccountInterface $account) 
   $url = Url::fromRoute('entity.node.canonical', ['node' => $node->id()], $options)->toString();
 
   try {
-    \Drupal::service('quant.token_manager')->validate($url, FALSE);
+    \Drupal::service('quant.token_manager')->validate($url, TRUE);
   }
   catch (ExpiredTokenException $e) {
     throw new ServiceUnavailableHttpException(3600, t('Service route is not available.'));

--- a/src/Exception/ExpiredTokenException.php
+++ b/src/Exception/ExpiredTokenException.php
@@ -2,13 +2,10 @@
 
 namespace Drupal\quant\Exception;
 
-use Exception;
-use Throwable;
-
 /**
  * The token has expired.
  */
-class ExpiredTokenException extends Exception {
+class ExpiredTokenException extends \Exception {
 
   /**
    * Request token.
@@ -34,7 +31,7 @@ class ExpiredTokenException extends Exception {
   /**
    * {@inheritdoc}
    */
-  public function __construct(string $token, int $time = 0, $record = [], string $message = "The token has expired", int $code = 0, Throwable $previous = NULL) {
+  public function __construct(string $token, int $time = 0, $record = [], string $message = "The token has expired", int $code = 0, \Throwable $previous = NULL) {
     $this->token = $token;
     $this->time = $time;
     $this->record = $record;

--- a/src/Exception/ExpiredTokenException.php
+++ b/src/Exception/ExpiredTokenException.php
@@ -34,7 +34,7 @@ class ExpiredTokenException extends Exception {
   /**
    * {@inheritdoc}
    */
-  public function __construct(string $token, int $time = 0, $record = [], string $message = "The token has expired", int $code = 0, Throwable $previous = null) {
+  public function __construct(string $token, int $time = 0, $record = [], string $message = "The token has expired", int $code = 0, Throwable $previous = NULL) {
     $this->token = $token;
     $this->time = $time;
     $this->record = $record;
@@ -56,6 +56,9 @@ class ExpiredTokenException extends Exception {
     return $this->time;
   }
 
+  /**
+   * Getter for the database record.
+   */
   public function getRecord() {
     return $this->record;
   }

--- a/src/Exception/ExpiredTokenException.php
+++ b/src/Exception/ExpiredTokenException.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Drupal\quant\Exception;
+
+use Exception;
+use Throwable;
+
+/**
+ * The token has expired.
+ */
+class ExpiredTokenException extends Exception {
+
+  /**
+   * Request token.
+   *
+   * @var string
+   */
+  protected $token;
+
+  /**
+   * Request time.
+   *
+   * @var int
+   */
+  protected $time;
+
+  /**
+   * The matched record.
+   *
+   * @var object
+   */
+  protected $record;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(string $token, int $time = 0, $record = [], string $message = "The token has expired", int $code = 0, Throwable $previous = null) {
+    $this->token = $token;
+    $this->time = $time;
+    $this->record = $record;
+
+    parent::__construct($message, $code, $previous);
+  }
+
+  /**
+   * Getter for the token.
+   */
+  public function getToken() {
+    return $this->token;
+  }
+
+  /**
+   * Getter for the time.
+   */
+  public function getTime() {
+    return $this->time;
+  }
+
+  public function getRecord() {
+    return $this->record;
+  }
+
+}

--- a/src/Exception/InvalidTokenException.php
+++ b/src/Exception/InvalidTokenException.php
@@ -27,7 +27,7 @@ class InvalidTokenException extends Exception {
   /**
    * {@inheritdoc}
    */
-  public function __construct(string $token, int $time = 0, string $message = "Invalid request token", int $code = 0, Throwable $previous = null) {
+  public function __construct(string $token, int $time = 0, string $message = "Invalid request token", int $code = 0, Throwable $previous = NULL) {
     $this->token = $token;
     $this->time = $time;
 

--- a/src/Exception/InvalidTokenException.php
+++ b/src/Exception/InvalidTokenException.php
@@ -2,13 +2,10 @@
 
 namespace Drupal\quant\Exception;
 
-use Exception;
-use Throwable;
-
 /**
  * The token has expired.
  */
-class InvalidTokenException extends Exception {
+class InvalidTokenException extends \Exception {
 
   /**
    * Token from the database.
@@ -27,7 +24,7 @@ class InvalidTokenException extends Exception {
   /**
    * {@inheritdoc}
    */
-  public function __construct(string $token, int $time = 0, string $message = "Invalid request token", int $code = 0, Throwable $previous = NULL) {
+  public function __construct(string $token, int $time = 0, string $message = "Invalid request token", int $code = 0, \Throwable $previous = NULL) {
     $this->token = $token;
     $this->time = $time;
 

--- a/src/Exception/InvalidTokenException.php
+++ b/src/Exception/InvalidTokenException.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Drupal\quant\Exception;
+
+use Exception;
+use Throwable;
+
+/**
+ * The token has expired.
+ */
+class InvalidTokenException extends Exception {
+
+  /**
+   * Token from the database.
+   *
+   * @var string
+   */
+  protected $token;
+
+  /**
+   * The request time.
+   *
+   * @var int
+   */
+  protected $time;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(string $token, int $time = 0, string $message = "Invalid request token", int $code = 0, Throwable $previous = null) {
+    $this->token = $token;
+    $this->time = $time;
+
+    parent::__construct($message, $code, $previous);
+  }
+
+  /**
+   * Getter for the token.
+   */
+  public function getToken() {
+    return $this->token;
+  }
+
+  /**
+   * Getter for the time.
+   */
+  public function getTime() {
+    return $this->time;
+  }
+
+}

--- a/src/Seed.php
+++ b/src/Seed.php
@@ -328,7 +328,7 @@ class Seed {
    * Replaces absolute URLs with relative in markup.
    *
    * @param string $markup
-   *   The markup to search and rewrie relative paths for.
+   *   The markup to search and rewire relative paths for.
    *
    * @return string
    *   Sanitised markup string.

--- a/src/TokenManager.php
+++ b/src/TokenManager.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\quant;
 
-use DateTime;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Database\Connection;
 use Drupal\quant\Exception\ExpiredTokenException;
@@ -96,7 +95,7 @@ class TokenManager {
     // issues with request time mismatches so for now we just
     // insert the request time for create.
     // $time = $this->request->getCurrentRequest()->server->get('REQUEST_TIME');
-    $time = new DateTime();
+    $time = new \DateTime();
     $token = $this->generate();
     $query = $this->connection->insert('quant_token')
       ->fields([
@@ -111,8 +110,6 @@ class TokenManager {
     catch (\Exception $error) {
       return FALSE;
     }
-
-    \Drupal::logger('quant_token')->notice('created token: ' . $token . ' route: ' . $route . ' time:' . $time->getTimestamp());
 
     return $token;
   }
@@ -138,7 +135,7 @@ class TokenManager {
   public function validate($route = NULL, $strict = TRUE) {
 
     $token = $this->request->getCurrentRequest()->headers->get('quant-token');
-    $time = new DateTime();
+    $time = new \DateTime();
     $time = $time->getTimestamp();
 
     if (empty($token)) {

--- a/src/TokenManager.php
+++ b/src/TokenManager.php
@@ -94,7 +94,6 @@ class TokenManager {
     // @todo table has DEFAULT now() but this was causing
     // issues with request time mismatches so for now we just
     // insert the request time for create.
-    // $time = $this->request->getCurrentRequest()->server->get('REQUEST_TIME');
     $time = new \DateTime();
     $token = $this->generate();
     $query = $this->connection->insert('quant_token')


### PR DESCRIPTION
- Changes token generation to use PHP `DateTime` rather than symfony request time
- Adds token exceptions for better error handling

When processing the queue with drush tokens are created by the Drush proc, when processing all items the proc is long running and symfony will set the initial create time with the proc open time of the Drush. This would cause each request token to be generated at the same time. As the queue progresses  requests would start to fail as the timeout would be exceeded.

```
$ drush queue:run quant_seed_worker
 [notice] [node_item] - node_id: 1 vid: 2
 [notice] created token: ZDk5N2QxNTEyYTViNjk3ZQ== route: /en/recipes/deep-mediterranean-quiche time:1623573280
 [notice] created token: OGYzMmUyYmY3ODM5YjA5MA== route: /es/recipes/quiche-mediterr%C3%A1neo-profundo time:1623573280
 [notice] [node_item] - node_id: 2 vid: 4
 [notice] created token: MTZlMzk4MzcyNTc1NDk3Ng== route: /en/recipes/vegan-chocolate-and-nut-brownies time:1623573280
 [notice] created token: YjhiNTk4MjNmYTk5NGIyMQ== route: /es/recipes/bizcochos-veganos-de-chocolate-y-nueces time:1623573280
 [notice] [node_item] - node_id: 3 vid: 6
 [notice] created token: MGQxMDFmMDA0Y2E3OTMxZA== route: /en/recipes/super-easy-vegetarian-pasta-bake time:1623573280
 [notice] created token: MWE4YjhmNWY3ZDU0OTU4Ng== route: /es/recipes/pasta-vegetariana-horno-super-facil time:1623573280
```

Changing to `DateTime` allows PHP to generate the timestamp as the process runs this should make the tokens that are created more inline with expectations and allows the short living tokens to be evaluated correctly.

```
$ drush queue:run quant_seed_worker
 [notice] [node_item] - node_id: 1 vid: 2
 [notice] created token: ZDY1OTIzMDEwNzgyYWVhNw== route: /en/recipes/deep-mediterranean-quiche time:1623573390
 [notice] created token: YTkwN2ZiMmRmZjhjMDVjMA== route: /es/recipes/quiche-mediterr%C3%A1neo-profundo time:1623573397
 [notice] [node_item] - node_id: 2 vid: 4
 [notice] created token: ZWE2YTQwNWNlNzA0YzhjYw== route: /en/recipes/vegan-chocolate-and-nut-brownies time:1623573404
 [notice] created token: MTEwNmJlMDI4ZDJhNGM4MQ== route: /es/recipes/bizcochos-veganos-de-chocolate-y-nueces time:1623573408
 [notice] [node_item] - node_id: 3 vid: 6
 [notice] created token: NWYxYzcyM2M0MTUxNWQyNg== route: /en/recipes/super-easy-vegetarian-pasta-bake time:1623573411
 [notice] created token: ZTBkNGFmNmYyYWExZWUwYQ== route: /es/recipes/pasta-vegetariana-horno-super-facil time:1623573415
```