### PR TITLE
Added simple threaded worker for processing quant queue.

### DIFF
--- a/drush.services.yml
+++ b/drush.services.yml
@@ -1,0 +1,5 @@
+services:
+  quantcdn.commands:
+    class: \Drupal\quant\Commands\QuantDrushCommands
+    tags:
+      - { name: drush.command }

--- a/src/Commands/QuantDrushCommands.php
+++ b/src/Commands/QuantDrushCommands.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\quant\Commands;
+
+use Drush\Commands\DrushCommands;
+
+/**
+ * A drush command file.
+ *
+ * @package Drupal\quant\Commands
+ */
+class QuantDrushCommands extends DrushCommands {
+
+  /**
+   * Drush command that executes the Quant queue.
+   *
+   * @command quant:run-queue
+   * @aliases quant-queue-run
+   * @option threads
+   *   Number of threads to use (default 5)
+   * @usage quant:run-queue --threads=5
+   */
+  public function message($options = ['threads' => 5]) {
+    $this->output()->writeln("Forking seed worker.");
+    for ($i=0; $i<$options['threads']; $i++) {
+      $cmd = 'drush queue:run quant_seed_worker';
+      $process = proc_open($cmd, array(), $pipes, NULL, NULL, array('bypass_shell' => TRUE));
+    }
+  }
+
+}
+


### PR DESCRIPTION
Simple threaded worker to process the quant queue with concurrency.
```
drush quant:run-queue --threads=40
```
