### PR TITLE
Revision history fix

### DIFF
--- a/src/Commands/QuantDrushCommands.php
+++ b/src/Commands/QuantDrushCommands.php
@@ -116,7 +116,7 @@ class QuantDrushCommands extends DrushCommands {
       $dispatcher->dispatch(QuantCollectionEvents::REDIRECTS, $event);
     }
 
-    if ($form_state->getValue('entity_node')) {
+    if ($form_state->getValue('entity_node') || $form_state->getValue('entity_node_revisions')) {
       $event = new CollectEntitiesEvent($form_state);
       $dispatcher->dispatch(QuantCollectionEvents::ENTITIES, $event);
     }

--- a/src/Event/CollectEntitiesEvent.php
+++ b/src/Event/CollectEntitiesEvent.php
@@ -27,4 +27,14 @@ class CollectEntitiesEvent extends ConfigFormEventBase {
     return (bool) $this->getFormState()->getValue('entity_node_revisions');
   }
 
+  /**
+   * Determine if should seed the latest revision.
+   *
+   * @return bool
+   *   Include latest revision or not.
+   */
+  public function includeLatest() {
+    return (bool) $this->getFormState()->getValue('entity_node');
+  }
+
 }

--- a/src/EventSubscriber/CollectionSubscriber.php
+++ b/src/EventSubscriber/CollectionSubscriber.php
@@ -75,18 +75,14 @@ class CollectionSubscriber implements EventSubscriberInterface {
     }
 
     $entities = $query->execute();
-    $revisions = $event->includeRevisions();
+    $includeLatest = $event->includeLatest();
+    $includeRevisions = $event->includeRevisions();
 
     // Add the latest node to the batch.
     foreach ($entities as $vid => $nid) {
       $filter = $event->getFormState()->getValue('entity_node_languages');
-      $event->queueItem([
-        'id' => $nid,
-        'vid' => $vid,
-        'lang_filter' => $filter,
-      ]);
 
-      if ($revisions) {
+      if ($includeRevisions) {
         $entity = Node::load($nid);
         $vids = \Drupal::entityTypeManager()->getStorage('node')->revisionIds($entity);
         $vids = array_diff($vids, [$vid]);
@@ -98,6 +94,15 @@ class CollectionSubscriber implements EventSubscriberInterface {
           ]);
         }
         $entity = NULL;
+      }
+
+      // Include latest revisions.
+      if ($includeLatest) {
+        $event->queueItem([
+          'id' => $nid,
+          'vid' => $vid,
+          'lang_filter' => $filter,
+        ]);
       }
     }
   }

--- a/src/Form/SeedForm.php
+++ b/src/Form/SeedForm.php
@@ -262,9 +262,22 @@ class SeedForm extends FormBase {
       '#type' => 'actions',
     ];
 
+    $form['actions']['save'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Save'),
+      '#op' => 'save',
+      '#attributes' => [
+        'class' => ['button--primary'],
+      ],
+    ];
+
     $form['actions']['submit'] = [
       '#type' => 'submit',
-      '#value' => $this->t('Queue'),
+      '#value' => $this->t('Save and Queue'),
+      '#op' => 'queue',
+      '#attributes' => [
+        'class' => ['button--secondary'],
+      ],
     ];
 
     return $form;
@@ -281,6 +294,7 @@ class SeedForm extends FormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $config = $this->configFactory->getEditable('quant_api.settings');
+    $trigger = $form_state->getTriggeringElement();
 
     $this->configFactory->getEditable(static::SETTINGS)
       ->set('entity_node', $form_state->getValue('entity_node'))
@@ -296,6 +310,11 @@ class SeedForm extends FormBase {
       ->set('robots', $form_state->getValue('robots'))
       ->set('lunr', $form_state->getValue('lunr'))
       ->save();
+
+    if (isset($trigger['#op']) && $trigger['#op'] == 'save') {
+      \Drupal::messenger()->addStatus(t('Successfully updated configuration.'));
+      return;
+    }
 
     if ($config->get('api_token')) {
       if (!$project = $this->client->ping()) {

--- a/src/Form/SeedForm.php
+++ b/src/Form/SeedForm.php
@@ -102,7 +102,32 @@ class SeedForm extends FormBase {
       '#type' => 'checkbox',
       '#title' => $this->t('Nodes'),
       '#description' => $this->t('Exports the latest revision of each node.'),
+      '#states' => [
+        'disabled' => [
+          ':input[name="entity_node_revisions"]' => ['checked' => TRUE],
+        ],
+        'unchecked' => [
+          ':input[name="entity_node_revisions"]' => ['checked' => TRUE],
+        ]
+      ],
       '#default_value' => $seed_config->get('entity_node'),
+    ];
+
+    $form['entity_node_disabled_explainer'] = [
+      '#type' => 'container',
+      '#markup' => $this->t('Push revision history independently of published revisions for best results.'),
+      '#states' => [
+        'visible' => [
+          ':input[name="entity_node_revisions"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+
+    $form['entity_node_revisions'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Nodes (revision history)'),
+      '#description' => $this->t('Exports the historic revision history for nodes. <em>Note: You should only perform this operation this once.</em>'),
+      '#default_value' => $seed_config->get('entity_node_revisions'),
     ];
 
     // Seed by language.
@@ -149,22 +174,15 @@ class SeedForm extends FormBase {
       '#options' => $content_types,
       '#states' => [
         'visible' => [
-          ':input[name="entity_node"]' => ['checked' => TRUE],
+          [
+            ':input[name="entity_node"]' => ['checked' => TRUE],
+          ],
+          [
+            ':input[name="entity_node_revisions"]' => ['checked' => TRUE],
+          ]
         ],
       ],
       '#default_value' => $seed_config->get('entity_node_bundles') ?: [],
-    ];
-
-    $form['entity_node_revisions'] = [
-      '#type' => 'checkbox',
-      '#title' => $this->t('All revisions'),
-      '#description' => $this->t('Exports all historic revisions.'),
-      '#states' => [
-        'visible' => [
-          ':input[name="entity_node"]' => ['checked' => TRUE],
-        ],
-      ],
-      '#default_value' => $seed_config->get('entity_node_revisions'),
     ];
 
     $form['entity_taxonomy_term'] = [
@@ -318,7 +336,7 @@ class SeedForm extends FormBase {
       $this->dispatcher->dispatch(QuantCollectionEvents::REDIRECTS, $event);
     }
 
-    if ($form_state->getValue('entity_node')) {
+    if ($form_state->getValue('entity_node') || $form_state->getValue('entity_node_revisions')) {
       $event = new CollectEntitiesEvent($form_state);
       $this->dispatcher->dispatch(QuantCollectionEvents::ENTITIES, $event);
     }

--- a/src/Form/SeedForm.php
+++ b/src/Form/SeedForm.php
@@ -150,7 +150,12 @@ class SeedForm extends FormBase {
         '#options' => $language_codes,
         '#states' => [
           'visible' => [
-            ':input[name="entity_node"]' => ['checked' => TRUE],
+            [
+              ':input[name="entity_node"]' => ['checked' => TRUE],
+            ],
+            [
+              ':input[name="entity_node_revisions"]' => ['checked' => TRUE],
+            ],
           ],
         ],
         '#default_value' => $seed_config->get('entity_node_languages') ?: [],

--- a/src/Form/SeedForm.php
+++ b/src/Form/SeedForm.php
@@ -108,7 +108,7 @@ class SeedForm extends FormBase {
         ],
         'unchecked' => [
           ':input[name="entity_node_revisions"]' => ['checked' => TRUE],
-        ]
+        ],
       ],
       '#default_value' => $seed_config->get('entity_node'),
     ];
@@ -179,7 +179,7 @@ class SeedForm extends FormBase {
           ],
           [
             ':input[name="entity_node_revisions"]' => ['checked' => TRUE],
-          ]
+          ],
         ],
       ],
       '#default_value' => $seed_config->get('entity_node_bundles') ?: [],

--- a/src/Plugin/Quant/Metadata/Published.php
+++ b/src/Plugin/Quant/Metadata/Published.php
@@ -54,7 +54,7 @@ class Published extends MetadataBase implements ContainerFactoryPluginInterface 
     // node. This should be used to make content non-viewable if it is
     // unpublished.
     // Return the published status of the revision.
-    return ['published' => $entity->isPublished()];
+    return ['published' => $entity->isPublished() && $entity->isDefaultRevision()];
   }
 
 }


### PR DESCRIPTION
- Splits historic revisions vs. active/published revisions
- Improved seed form for node vs. node revision history