### PR TITLE
Use JWT to sign requests for Quant

### DIFF
--- a/config/install/quant.token_settings.yml
+++ b/config/install/quant.token_settings.yml
@@ -1,2 +1,4 @@
 timeout: '+1 minute'
 disable: false
+secret: null
+strict: false

--- a/config/install/quant.token_settings.yml
+++ b/config/install/quant.token_settings.yml
@@ -1,4 +1,4 @@
 timeout: '+1 minute'
-disable: false
+disable: 0
 secret: null
-strict: false
+strict: 0

--- a/modules/quant_sitemap/src/EventSubscriber/CollectionSubscriber.php
+++ b/modules/quant_sitemap/src/EventSubscriber/CollectionSubscriber.php
@@ -118,7 +118,7 @@ class CollectionSubscriber implements EventSubscriberInterface {
     }
 
     foreach ($items as $route) {
-      $event->addRoute($route);
+      $event->queueItem(['route' => $route]);
     }
   }
 

--- a/quant.install
+++ b/quant.install
@@ -8,50 +8,12 @@
 use Drupal\Core\Database\Database;
 
 /**
- * Implements hook_schema().
- *
- * Defines a simple table to store salted tokens.
- *
- * @see hook_schema()
- *
- * @ingroup quant
+ * Perform setup tasks for Quant.
  */
-function quant_schema() {
-  $schema['quant_token'] = [
-    'description' => 'Stores short-lived access tokens.',
-    'fields' => [
-      'pid' => [
-        'type' => 'serial',
-        'not null' => TRUE,
-        'description' => 'Primary key: Unique token ID.',
-      ],
-      'token' => [
-        'type' => 'varchar',
-        'not null' => TRUE,
-        'length' => 255,
-        'default' => '',
-        'description' => 'The token value.',
-      ],
-      'route' => [
-        'type' => 'text',
-        'size' => 'normal',
-        'not null' => FALSE,
-        'description' => 'A path to register for the token',
-      ],
-      'created' => [
-        'type' => 'int',
-        'size' => 'normal',
-        'not null' => TRUE,
-        'description' => 'When the token was created.',
-      ],
-    ],
-    'primary key' => ['pid'],
-    'indexes' => [
-      'token' => ['token'],
-    ],
-  ];
-
-  return $schema;
+function quant_install() {
+  $config = \Drupal::configFactory()->getEditable('quant.token_settings');
+  $config->set('secret', bin2hex(random_bytes(32)));
+  $config->save();
 }
 
 /**
@@ -93,4 +55,18 @@ function quant_update_9002(&$sandbox) {
   $config = \Drupal::configFactory()->getEditable('quant.token_settings');
   $config->set('disable', FALSE);
   $config->save();
+}
+
+/**
+ * Support JWT for internal request tokens.
+ */
+function quant_update_9003(&$sandbox) {
+  $config = \Drupal::configFactory()->getEditable('quant.token_settings');
+  $config->set('secret', bin2hex(random_bytes(32)));
+  $config->set('strict', FALSE);
+  $config->save();
+
+  // Remove the token table.
+  $schema = \Database::getConnection()->schema();
+  $schema->dropTable('quant_token');
 }

--- a/quant.install
+++ b/quant.install
@@ -67,6 +67,6 @@ function quant_update_9003(&$sandbox) {
   $config->save();
 
   // Remove the token table.
-  $schema = \Database::getConnection()->schema();
+  $schema = Database::getConnection()->schema();
   $schema->dropTable('quant_token');
 }

--- a/quant.links.menu.yml
+++ b/quant.links.menu.yml
@@ -19,7 +19,6 @@ quant.token:
   parent: quant
   weight: 2
 
-
 quant.metadata:
   title: 'Metadata'
   route_name: quant.metadata

--- a/quant.links.task.yml
+++ b/quant.links.task.yml
@@ -8,6 +8,11 @@ quant.seed:
   title: 'Seed'
   base_route: quant.config
 
+quant.token:
+  route_name: quant.token
+  title: 'Token'
+  base_route: quant.config
+
 quant.metadata:
   route_name: quant.metadata
   title: Metadata

--- a/quant.module
+++ b/quant.module
@@ -167,7 +167,6 @@ function quant_shutdown(array $context = []) {
  * Implements hook_node_access().
  */
 function quant_node_access(NodeInterface $node, $op, AccountInterface $account) {
-  $strict = \Drupal::config('quant.token_settings')->get('strict');
   $request = \Drupal::request();
 
   if (!$request->headers->has('quant-revision') && !$request->headers->has('quant-token')) {
@@ -178,41 +177,24 @@ function quant_node_access(NodeInterface $node, $op, AccountInterface $account) 
   $url = Url::fromRoute('entity.node.canonical', ['node' => $node->id()], $options)->toString();
 
   try {
-    \Drupal::service('quant.token_manager')->validate($url, $strict);
+    // Token validation for node access cannot be strict as this will be called
+    // for embedded entities on a page the token process is bound to requests
+    // if the incoming request has a valid token we assume that all
+    // embedded entities are valid.
+    //
+    // @see Drupal\quant\EventSubscriber\TokenAccessSubscriber
+    \Drupal::service('quant.token_manager')->validate($url, FALSE);
   }
   catch (TokenValidationDisabledException $e) {
     // Allow access when token validation is disabled.
   }
-  catch (ExpiredTokenException $e) {
-    throw new ServiceUnavailableHttpException(NULL, t('Token request: time mismatch. Received [:token_time] expected [:server_time]', [
-      ':token_time' => $e->getTime(),
-      ':server_time' => $e->getServerTime(),
-    ]));
-  }
-  catch (StrictTokenException $e) {
-    throw new ServiceUnavailableHttpException(NULL, t('Token request: route mismatch. Received [:route] expected [:expected]', [
-      ':route' => $e->getTokenRoute(),
-      ':expected' => $e->getExpectedRoute(),
-    ]));
-  }
-  catch (InvalidTokenException $e) {
-    throw new ServiceUnavailableHttpException(NULL, t('Token request: Invalid token'));
+  catch (\Exception $e) {
+    return AccessResult::neutral();
   }
 
   // If the token validation didn't trigger an exception - then the
-  // token is valid and can be continued to be evaluated to allow
-  // access to the node.
-  $routeNode = \Drupal::routeMatch()->getParameter('node');
-
-  if (!empty($routeNode)) {
-    $nid = $routeNode->id();
-
-    if ($nid == $node->id()) {
-      return AccessResult::allowed();
-    }
-  }
-
-  return AccessResult::neutral();
+  // token is valid and can be continued.
+  return AccessResult::allowed();
 }
 
 /**

--- a/quant.module
+++ b/quant.module
@@ -11,13 +11,9 @@ use Drupal\node\NodeInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
-use Drupal\quant\Exception\ExpiredTokenException;
-use Drupal\quant\Exception\InvalidTokenException;
-use Drupal\quant\Exception\StrictTokenException;
 use Drupal\quant\Exception\TokenValidationDisabledException;
 use Drupal\quant\Plugin\QueueItem\RouteItem;
 use Drupal\quant\Seed;
-use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 
 /**
  * Implements hook_menu_local_tasks_alter().

--- a/quant.module
+++ b/quant.module
@@ -13,6 +13,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\quant\Exception\ExpiredTokenException;
 use Drupal\quant\Exception\InvalidTokenException;
+use Drupal\quant\Exception\StrictTokenException;
 use Drupal\quant\Exception\TokenValidationDisabledException;
 use Drupal\quant\Plugin\QueueItem\RouteItem;
 use Drupal\quant\Seed;
@@ -163,16 +164,10 @@ function quant_shutdown(array $context = []) {
 }
 
 /**
- * Implements hook_cron().
- */
-function quant_cron() {
-  \Drupal::service('quant.token_manager')->release();
-}
-
-/**
  * Implements hook_node_access().
  */
 function quant_node_access(NodeInterface $node, $op, AccountInterface $account) {
+  $strict = \Drupal::config('quant.token_settings')->get('strict');
   $request = \Drupal::request();
 
   if (!$request->headers->has('quant-revision') && !$request->headers->has('quant-token')) {
@@ -183,16 +178,25 @@ function quant_node_access(NodeInterface $node, $op, AccountInterface $account) 
   $url = Url::fromRoute('entity.node.canonical', ['node' => $node->id()], $options)->toString();
 
   try {
-    \Drupal::service('quant.token_manager')->validate($url, TRUE);
+    \Drupal::service('quant.token_manager')->validate($url, $strict);
   }
   catch (TokenValidationDisabledException $e) {
-
+    // Allow access when token validation is disabled.
   }
   catch (ExpiredTokenException $e) {
-    throw new ServiceUnavailableHttpException(NULL, t('Service route is not available.'));
+    throw new ServiceUnavailableHttpException(NULL, t('Token request: time mismatch. Received [:token_time] expected [:server_time]', [
+      ':token_time' => $e->getTime(),
+      ':server_time' => $e->getServerTime(),
+    ]));
+  }
+  catch (StrictTokenException $e) {
+    throw new ServiceUnavailableHttpException(NULL, t('Token request: route mismatch. Received [:route] expected [:expected]', [
+      ':route' => $e->getTokenRoute(),
+      ':expected' => $e->getExpectedRoute(),
+    ]));
   }
   catch (InvalidTokenException $e) {
-    throw new ServiceUnavailableHttpException(NULL, t('Service route is not available.'));
+    throw new ServiceUnavailableHttpException(NULL, t('Token request: Invalid token'));
   }
 
   // If the token validation didn't trigger an exception - then the

--- a/quant.services.yml
+++ b/quant.services.yml
@@ -30,3 +30,11 @@ services:
       - '@request_stack'
       - '@config.factory'
       - '@datetime.time'
+
+  quant.token_subscriber:
+    class: Drupal\quant\EventSubscriber\TokenAccessSubscriber
+    arguments:
+      - '@quant.token_manager'
+      - '@config.factory'
+    tags:
+      - { name: 'event_subscriber' }

--- a/quant.services.yml
+++ b/quant.services.yml
@@ -29,3 +29,4 @@ services:
       - '@database'
       - '@request_stack'
       - '@config.factory'
+      - '@datetime.time'

--- a/src/EventSubscriber/TokenAccessSubscriber.php
+++ b/src/EventSubscriber/TokenAccessSubscriber.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Drupal\quant\EventSubscriber;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\quant\Exception\ExpiredTokenException;
+use Drupal\quant\Exception\InvalidTokenException;
+use Drupal\quant\Exception\StrictTokenException;
+use Drupal\quant\Exception\TokenValidationDisabledException;
+use Drupal\quant\TokenManager;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
+
+class TokenAccessSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The token manager.
+   *
+   * @var \Drupal\quant\TokenManager
+   */
+  protected $tokenManager;
+
+  protected $config;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(TokenManager $token_manager, ConfigFactoryInterface $config_factory) {
+    $this->tokenManager = $token_manager;
+    $this->config = $config_factory->get('quant.token_settings');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[KernelEvents::REQUEST][] = ['validateToken'];
+    return $events;
+  }
+
+  /**
+   * Validate the token on the incoming request.
+   */
+  public function validateToken(GetResponseEvent $event) {
+    /* @var $request Symfony\Component\HttpFoundation\Request */
+    $request = $event->getRequest();
+
+    if (!$request->headers->has('quant-token')) {
+      return;
+    }
+
+    try {
+      \Drupal::service('quant.token_manager')->validate($request->getPathInfo(), $this->config->get('strict'));
+    }
+    catch (TokenValidationDisabledException $e) {
+      // Allow access when token validation is disabled.
+    }
+    catch (ExpiredTokenException $e) {
+      throw new ServiceUnavailableHttpException(NULL, t('Token request: time mismatch. Received [:token_time] expected [:server_time]', [
+        ':token_time' => $e->getTime(),
+        ':server_time' => $e->getServerTime(),
+      ]));
+    }
+    catch (StrictTokenException $e) {
+      throw new ServiceUnavailableHttpException(NULL, t('Token request: route mismatch. Received [:route] expected [:expected]', [
+        ':route' => $e->getTokenRoute(),
+        ':expected' => $e->getExpectedRoute(),
+      ]));
+    }
+    catch (InvalidTokenException $e) {
+      throw new ServiceUnavailableHttpException(NULL, t('Token request: Invalid token'));
+    }
+  }
+
+}

--- a/src/EventSubscriber/TokenAccessSubscriber.php
+++ b/src/EventSubscriber/TokenAccessSubscriber.php
@@ -13,6 +13,9 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 
+/**
+ * Validates token for internal requests.
+ */
 class TokenAccessSubscriber implements EventSubscriberInterface {
 
   /**
@@ -22,6 +25,11 @@ class TokenAccessSubscriber implements EventSubscriberInterface {
    */
   protected $tokenManager;
 
+  /**
+   * The config factory.
+   *
+   * @var Drupal\Core\Config\ConfigFactory
+   */
   protected $config;
 
   /**
@@ -44,7 +52,7 @@ class TokenAccessSubscriber implements EventSubscriberInterface {
    * Validate the token on the incoming request.
    */
   public function validateToken(GetResponseEvent $event) {
-    /* @var $request Symfony\Component\HttpFoundation\Request */
+    /** @var Symfony\Component\HttpFoundation\Request $request */
     $request = $event->getRequest();
 
     if (!$request->headers->has('quant-token')) {

--- a/src/Exception/StrictTokenException.php
+++ b/src/Exception/StrictTokenException.php
@@ -5,7 +5,7 @@ namespace Drupal\quant\Exception;
 /**
  * The token has expired.
  */
-class ExpiredTokenException extends \Exception {
+class StrictTokenException extends \Exception {
 
   /**
    * Request token.
@@ -17,24 +17,24 @@ class ExpiredTokenException extends \Exception {
   /**
    * Request time.
    *
-   * @var int
+   * @var string
    */
-  protected $time;
+  protected $tokenRoute;
 
   /**
    * The matched record.
    *
-   * @var int
+   * @var string
    */
-  protected $sTime;
+  protected $expectedRoute;
 
   /**
    * {@inheritdoc}
    */
-  public function __construct(string $token, int $time = 0, $sTime = 0, string $message = "The token has expired", int $code = 0, \Throwable $previous = NULL) {
+  public function __construct(string $token, $token_route = NULL, $expected_route = NULL, string $message = "The token routes do not match", int $code = 0, \Throwable $previous = NULL) {
     $this->token = $token;
-    $this->time = $time;
-    $this->sTime = $sTime;
+    $this->tokenRoute = $token_route;
+    $this->expectedRoute = $expected_route;
 
     parent::__construct($message, $code, $previous);
   }
@@ -49,15 +49,15 @@ class ExpiredTokenException extends \Exception {
   /**
    * Getter for the time.
    */
-  public function getTime() {
-    return $this->time;
+  public function getTokenRoute() {
+    return $this->tokenRoute;
   }
 
   /**
    * Getter for the database record.
    */
-  public function getServerTime() {
-    return $this->sTime;
+  public function getExpectedRoute() {
+    return $this->expectedRoute;
   }
 
 }

--- a/src/Form/TokenForm.php
+++ b/src/Form/TokenForm.php
@@ -44,7 +44,7 @@ class TokenForm extends ConfigFormBase {
     $form['strict'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Enable strict tokens'),
-      '#description' => $this->t('Allow token verificaiton process to perform route validations, this may not work for all Drupal configurations.'),
+      '#description' => $this->t('Allow token verification process to perform route validations. This may not work for all Drupal configurations'),
       '#default_value' => $config->get('strict'),
     ];
 
@@ -89,6 +89,10 @@ class TokenForm extends ConfigFormBase {
 
     if ($form_state->getValue('generate_secret') || empty($config->get('secret'))) {
       $editable->set('secret', bin2hex(random_bytes(32)));
+    }
+
+    if ($form_state->getValue('disable')) {
+      $form_state->setValue('strict', 0);
     }
 
     $editable

--- a/src/Form/TokenForm.php
+++ b/src/Form/TokenForm.php
@@ -91,10 +91,10 @@ class TokenForm extends ConfigFormBase {
       $editable->set('secret', bin2hex(random_bytes(32)));
     }
 
-    $this->configFactory->getEditable(static::SETTINGS)
+    $editable
       ->set('timeout', $form_state->getValue('timeout'))
       ->set('disable', $form_state->getValue('disable'))
-      ->set('strict', $form_state->get('strict'))
+      ->set('strict', $form_state->getValue('strict'))
       ->save();
 
     parent::submitForm($form, $form_state);

--- a/src/TokenManager.php
+++ b/src/TokenManager.php
@@ -143,6 +143,7 @@ class TokenManager {
     $token_parts = explode('.', $token);
     $header = json_decode(base64_decode($token_parts[0]), TRUE);
     $payload = json_decode(base64_decode($token_parts[1]), TRUE);
+
     $provided_signature = $token_parts[2];
 
     $signature = hash_hmac('sha256', "{$token_parts[0]}.{$token_parts[1]}", $secret, TRUE);


### PR DESCRIPTION
This is a general rewrite of the token mechanism used by Quant to verify internal requests.

- Updates token mechanism to use a secret salt and JWT
-- Adds JWT creation for create method
-- Adds JWT reversal
- Adds configuration form for token settings
- Removes quant_token table
- Adds configuration for `strict` token verification
- Adds strict token error class for better error handling