### PR TITLE
Skipping node_modules folder in theme assets collector.

### DIFF
--- a/src/EventSubscriber/CollectionSubscriber.php
+++ b/src/EventSubscriber/CollectionSubscriber.php
@@ -160,6 +160,11 @@ class CollectionSubscriber implements EventSubscriberInterface {
     $regex = new \RegexIterator($iterator, '/^.+(.jpe?g|.png|.svg|.ttf|.woff|.woff2|.otf|.ico|.js|.css)$/i', \RecursiveRegexIterator::GET_MATCH);
 
     foreach ($regex as $name => $r) {
+      // Skip node_modules.
+      if (preg_match('/node_modules/i', $name)) {
+        continue;
+      }
+
       $path = str_replace(DRUPAL_ROOT, '', $name);
       $event->queueItem(['file' => $path]);
     }


### PR DESCRIPTION
h2. Issue
When seeding  the site the module pulls `node_modules` folder in which is heavy - this slows down the sync.

h2. Solution
Seeing that `node_modules` is not required for static website this PR it has been explicitly skipped.