### PR TITLE
Added `quant_search` module

### DIFF
--- a/modules/quant_api/src/Client/QuantClient.php
+++ b/modules/quant_api/src/Client/QuantClient.php
@@ -116,6 +116,82 @@ class QuantClient implements QuantClientInterface {
   /**
    * {@inheritdoc}
    */
+  public function project() {
+
+    try {
+      $response = $this->client->get($this->endpoint . "/ping", [
+        'http_errors' => FALSE,
+        'headers' => [
+          'Quant-Customer' => $this->username,
+          'Quant-Project'  => $this->project,
+          'Quant-Token'    => $this->token,
+        ],
+        'exceptions' => FALSE,
+      ]);
+    }
+    catch (RequestException $e) {
+      \Drupal::messenger()->addError($e->getMessage());
+      return FALSE;
+    }
+
+    if ($response->getStatusCode() == 200) {
+      return json_decode($response->getBody());
+    }
+
+    if ($response->getStatusCode() == 402) {
+      // Emit a subscription invalid warning.
+      \Drupal::messenger()->addError(t('Your Quant subscription is invalid. Please check the dashboard.'));
+    }
+
+    if ($response->getStatusCode() == 410) {
+      // Emit a deleted project warning.
+      \Drupal::messenger()->addError(t('Project is deleted. Please check the dashboard for restoration options.'));
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function search() {
+
+    try {
+      $response = $this->client->get($this->endpoint . "/search", [
+        'http_errors' => FALSE,
+        'headers' => [
+          'Quant-Customer' => $this->username,
+          'Quant-Project'  => $this->project,
+          'Quant-Token'    => $this->token,
+        ],
+        'exceptions' => FALSE,
+      ]);
+    }
+    catch (RequestException $e) {
+      \Drupal::messenger()->addError($e->getMessage());
+      return FALSE;
+    }
+
+    if ($response->getStatusCode() == 200) {
+      return json_decode($response->getBody());
+    }
+
+    if ($response->getStatusCode() == 402) {
+      // Emit a subscription invalid warning.
+      \Drupal::messenger()->addError(t('Your Quant subscription is invalid. Please check the dashboard.'));
+    }
+
+    if ($response->getStatusCode() == 410) {
+      // Emit a deleted project warning.
+      \Drupal::messenger()->addError(t('Project is deleted. Please check the dashboard for restoration options.'));
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function send(array $data) : array {
     $response = $this->client->post($this->endpoint, [
       RequestOptions::JSON => $data,
@@ -201,6 +277,56 @@ class QuantClient implements QuantClientInterface {
     $response = $this->client->patch($this->endpoint . '/unpublish', [
       'headers' => [
         'Quant-Url' => $url,
+        'Quant-Customer' => $this->username,
+        'Quant-Project'  => $this->project,
+        'Quant-Token'    => $this->token,
+      ],
+      'verify' => $this->tlsDisabled ? FALSE : TRUE,
+    ]);
+
+    return json_decode($response->getBody(), TRUE);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function sendSearchRecords(array $records) : array {
+    $response = $this->client->post($this->endpoint . '/search', [
+      RequestOptions::JSON => $records,
+      'headers' => [
+        'Quant-Customer' => $this->username,
+        'Quant-Project'  => $this->project,
+        'Quant-Token'    => $this->token,
+      ],
+      'verify' => $this->tlsDisabled ? FALSE : TRUE,
+    ]);
+
+    return json_decode($response->getBody(), TRUE);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function clearSearchIndex() : array {
+    $response = $this->client->delete($this->endpoint . '/search/all', [
+      'headers' => [
+        'Quant-Customer' => $this->username,
+        'Quant-Project'  => $this->project,
+        'Quant-Token'    => $this->token,
+      ],
+      'verify' => $this->tlsDisabled ? FALSE : TRUE,
+    ]);
+
+    return json_decode($response->getBody(), TRUE);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function addFacets(array $facets) : array {
+    $response = $this->client->post($this->endpoint . '/search/facet', [
+      RequestOptions::JSON => $facets,
+      'headers' => [
         'Quant-Customer' => $this->username,
         'Quant-Project'  => $this->project,
         'Quant-Token'    => $this->token,

--- a/modules/quant_api/src/Client/QuantClientInterface.php
+++ b/modules/quant_api/src/Client/QuantClientInterface.php
@@ -16,6 +16,22 @@ interface QuantClientInterface {
   public function ping();
 
   /**
+   * Retrieves project data.
+   *
+   * @return mixed
+   *   Contains object containing project information.
+   */
+  public function project();
+
+  /**
+   * Retrieves project search configuration.
+   *
+   * @return mixed
+   *   Contains object containing search information.
+   */
+  public function search();
+
+  /**
    * Send a payload to the API.
    *
    * @param array $data
@@ -72,5 +88,35 @@ interface QuantClientInterface {
    *   The API response.
    */
   public function unpublish(string $url) : array;
+
+  /**
+   * Send a search record payload to Quant.
+   *
+   * @param array $records
+   *   The array of search records to submit.
+   *
+   * @return array
+   *   The API response.
+   */
+  public function sendSearchRecords(array $records) : array;
+
+  /**
+   * Clear a search index.
+   *
+   * @return array
+   *   The API response.
+   */
+  public function clearSearchIndex() : array;
+
+  /**
+   * Ensure facets are appropriated enabled in Quant Search.
+   *
+   * @param array $facets
+   *   The array of facet keys to ensure are enabled.
+   *
+   * @return array
+   *   The API response.
+   */
+  public function addFacets(array $facets) : array;
 
 }

--- a/modules/quant_api/src/EventSubscriber/QuantApi.php
+++ b/modules/quant_api/src/EventSubscriber/QuantApi.php
@@ -41,7 +41,7 @@ class QuantApi implements EventSubscriberInterface {
   protected $eventDispatcher;
 
   /**
-   * QuantAPI event subcsriber.
+   * QuantAPI event subscriber.
    *
    * Listens to Quant events and triggers requests to the configured
    * API endpoint for different operations.
@@ -63,10 +63,10 @@ class QuantApi implements EventSubscriberInterface {
    * {@inheritdoc}
    */
   public static function getSubscribedEvents() {
-    $events[QuantEvent::OUTPUT][] = ['onOutput'];
-    $events[QuantFileEvent::OUTPUT][] = ['onMedia'];
-    $events[QuantRedirectEvent::UPDATE][] = ['onRedirect'];
-    $events[QuantEvent::UNPUBLISH][] = ['onUnpublish'];
+    $events[QuantEvent::OUTPUT] = ['onOutput', -999];
+    $events[QuantFileEvent::OUTPUT] = ['onMedia', -999];
+    $events[QuantRedirectEvent::UPDATE] = ['onRedirect', -999];
+    $events[QuantEvent::UNPUBLISH] = ['onUnpublish', -999];
     return $events;
   }
 

--- a/modules/quant_purger/src/Form/ConfigurationForm.php
+++ b/modules/quant_purger/src/Form/ConfigurationForm.php
@@ -58,7 +58,7 @@ class ConfigurationForm extends QueuerConfigFormBase {
         if (empty($form["{$key}_fieldset"][$key][$delta])) {
           $form["{$key}_fieldset"][$key][$delta] = [
             '#type' => 'textfield',
-            '#default_value' => isset($items[$delta]) ? $items[$delta] : '',
+            '#default_value' => $items[$delta] ?? '',
           ];
         }
       }

--- a/modules/quant_search/config/install/quant_search.entities.settings.yml
+++ b/modules/quant_search/config/install/quant_search.entities.settings.yml
@@ -1,0 +1,6 @@
+quant_search_entity_node: 1
+quant_search_title_token: '[node:title]'
+quant_search_summary_token: '[node:summary]'
+quant_search_content_viewmode: full
+quant_search_image_token: '[node:field_media_image:entity:field_media_image:large_3_2_2x:url]'
+quant_search_entity_taxonomy_term: 1

--- a/modules/quant_search/config/schema/quant_search_page.schema.yml
+++ b/modules/quant_search/config/schema/quant_search_page.schema.yml
@@ -1,0 +1,10 @@
+quant_search.quant_search_page.*:
+  type: config_entity
+  label: 'Quant search page config'
+  mapping:
+    id:
+      type: string
+      label: 'ID'
+    label:
+      type: label
+      label: 'Label'

--- a/modules/quant_search/css/quant-search.css
+++ b/modules/quant_search/css/quant-search.css
@@ -1,0 +1,159 @@
+.quant-search .flex-grid {
+  display: flex;
+}
+
+.quant-search .col.content {
+  flex-grow: 1;
+}
+
+.quant-search .col.facets {
+  min-width: 20%;
+  margin-right: 2em;
+}
+
+@media (max-width: 600px) {
+  .quant-search .flex-grid {
+    display: block;
+  }
+  .quant-search {
+    margin: 1em;
+  }
+}
+
+.quant-search .facet-container {
+  margin-bottom: 40px;
+}
+
+.quant-search .facet-heading {
+  margin-bottom: 10px;
+  border-bottom: 1px solid #e9edf2;
+  text-transform: uppercase;
+  font-size: 0.75em;
+  font-weight: 600;
+}
+
+.quant-search img {
+  max-width: 100%;
+  height: auto;
+}
+
+.quant-search .ais-ClearRefinements {
+  margin: 1em 0;
+}
+
+.quant-search .ais-SearchBox {
+  margin: 1em 0;
+}
+
+.quant-search .ais-Pagination {
+  margin: 2em 0;
+}
+
+.quant-search .ais-Pagination-link {
+  border-radius: 0;
+}
+
+.quant-search .ais-InstantSearch {
+  max-width: 960px;
+  overflow: hidden;
+  margin: 0 auto;
+}
+
+.quant-search .ais-Hits-item {
+  margin-bottom: 1em;
+  width: calc(50% - 1rem);
+  border: none;
+  box-shadow: 0 2px 5px 0 #e3e5ec;
+  background: #fff;
+}
+
+.quant-search .ais-Highlight-highlighted,
+.ais-Snippet-highlighted {
+  background-color: #e7eefa;
+}
+
+.quant-search .ais-SearchBox-input {
+  height: 50px;
+  font-size: 1.2em;
+  border-radius: 0;
+  padding: 0.3rem 4rem;
+}
+
+.quant-search .ais-SearchBox-submitIcon {
+  width: 20px;
+  height: 20px;
+}
+
+.quant-search .ais-SearchBox-submit {
+  left: 1rem;
+}
+
+.quant-search .ais-Hits-item img {
+  margin-right: 1em;
+}
+
+.quant-search .ais-Hits-item a {
+  font-size: 1.1em;
+  font-weight: 500;
+  text-decoration: none;
+  color: #5878f9;
+  margin-top: 1em;
+}
+
+.quant-search .hit-name {
+  margin: 1em 0;
+}
+
+.quant-search .hit-description {
+  color: #666;
+  font-size: 14px;
+  margin-bottom: 0.5em;
+}
+
+.quant-search .hit-tag {
+  background-color: #dcdcdc;
+  color: #5a5a5a;
+  text-transform: uppercase;
+  font-size: 0.75em;
+  font-weight: 600;
+  padding: 5px 10px;
+  margin-right: 10px;
+  border-radius: 3px;
+}
+
+.quant-search .hit-tags {
+  clear: both;
+  margin-top: 20px;
+}
+
+.quant-search .ais-Hits-item {
+  margin-bottom: 1em;
+  width: 100%;
+  border: none;
+  box-shadow: none;
+  background: none;
+}
+
+.quant-search .ais-Hits-item:hover {
+  box-shadow: 0 2px 5px 0 #e3e5ec;
+  background: #fff;
+}
+
+.quant-search .ais-Hits-item img {
+  max-width: 100px;
+  float: left;
+}
+
+.quant-search .hit-name {
+  margin-top: 0;
+}
+
+.quant-search [class^=ais-] {
+  font-size: inherit;
+}
+
+.quant-search button,
+.quant-search button:hover {
+  border: none;
+  background-color: transparent;
+}

--- a/modules/quant_search/js/quant-search.js
+++ b/modules/quant_search/js/quant-search.js
@@ -1,0 +1,149 @@
+(function(Drupal, drupalSettings, once) {
+    Drupal.behaviors.searchPageInit = {
+        attach: function(context, settings) {
+            once('searchPageInit', 'html', context).forEach(function(element) {
+
+                /* global instantsearch algoliasearch */
+                function getParameterByName(name) {
+                    const match = RegExp('[?&]' + name + '=([^&]*)').exec(window.location.search)
+                    return match && decodeURIComponent(match[1].replace(/\+/g, ' '))
+                }
+
+                const search = instantsearch({
+                    indexName: drupalSettings.quantSearch.algolia_index,
+                    searchClient: algoliasearch(drupalSettings.quantSearch.algolia_application_id, drupalSettings.quantSearch.algolia_read_key),
+                    routing: true,
+                    initialUiState: {
+                        [drupalSettings.quantSearch.algolia_index]: {
+                            query: getParameterByName('keys')
+                        }
+                    }
+                });
+
+                search.templatesConfig.helpers.image = function(text, render) {
+                    if (render(text)) {
+                        return '<img ' +
+                            'src="' + render(text) + '" ' +
+                            'alt="' + render("{{title}}") + '" ' +
+                            '/>';
+                    }
+                };
+
+                search.templatesConfig.helpers.tags = function(text, render) {
+                    if (render('{{' + text + '}}')) {
+                        const tags = render('{{' + text + '}}');
+                        var markup = '';
+                        for (tag of tags.split(',')) {
+                            markup += '<span class="hit-tag">' + tag + '</span>';
+                        }
+                        return markup;
+                    }
+                };
+
+                if (drupalSettings.quantSearch.display.results.display_search) {
+                    search.addWidgets([
+                        instantsearch.widgets.searchBox({
+                            container: '#searchbox',
+                        }),
+                    ]);
+                }
+
+
+                if (drupalSettings.quantSearch.display.results.show_clear_refinements) {
+                    search.addWidgets([
+                        instantsearch.widgets.clearRefinements({
+                            container: '#clear-refinements',
+                        }),
+                    ]);
+                }
+
+                if (drupalSettings.quantSearch.display.pagination.pagination_enabled) {
+                    search.addWidgets([
+                        instantsearch.widgets.pagination({
+                            container: '#pagination',
+                        }),
+                    ]);
+                }
+
+                if (drupalSettings.quantSearch.display.results.display_stats) {
+                    search.addWidgets([
+                        instantsearch.widgets.stats({
+                            container: '#stats',
+                            templates: {
+                                text: `
+                        {{#hasOneResult}}1 result{{/hasOneResult}}
+                        {{#hasManyResults}}{{#helpers.formatNumber}}{{nbHits}}{{/helpers.formatNumber}} results{{/hasManyResults}}
+                        `,
+                            },
+                        }),
+                    ]);
+                }
+
+                for (var facet_key in drupalSettings.quantSearch.facets) {
+                    const facet = drupalSettings.quantSearch.facets[facet_key];
+
+                    switch (facet.facet_display) {
+                        case "checkbox":
+                            search.addWidgets([
+                                instantsearch.widgets.refinementList({
+                                    container: '#facet_' + facet.facet_container,
+                                    attribute: facet.facet_key,
+                                }),
+                            ]);
+                            break;
+
+                        case "menu":
+                            search.addWidgets([
+                                instantsearch.widgets.menu({
+                                    container: '#facet_' + facet.facet_container,
+                                    attribute: facet.facet_key,
+                                }),
+                            ]);
+                            break;
+
+                        case "select":
+                            search.addWidgets([
+                                instantsearch.widgets.menuSelect({
+                                    container: '#facet_' + facet.facet_container,
+                                    attribute: facet.facet_key,
+                                }),
+                            ]);
+                            break;
+                    }
+                }
+
+                search.addWidgets([
+                    instantsearch.widgets.configure({
+                        attributesToSnippet: ['summary:100'],
+                        snippetEllipsisText: '…',
+                        filters: drupalSettings.quantSearch.filters,
+                        hitsPerPage: drupalSettings.quantSearch.display.pagination.per_page
+                    }),
+                    instantsearch.widgets.hits({
+                        container: '#hits',
+                        templates: {
+                            empty: '<h4>No results found.</h4><p>Please try again with different search terms or filters.</p>',
+                            item: `
+                    <div>
+                        <a href="{{url}}">
+                        {{#helpers.image}}{{image}}{{/helpers.image}}
+                        <h4 class="hit-name">
+                            {{#helpers.highlight}}{ "attribute": "title" }{{/helpers.highlight}}
+                        </h4>
+                        </a>
+                        <div class="hit-description">
+                            {{#helpers.snippet}}{ "attribute": "summary" }{{/helpers.snippet}}
+                        </div>
+                    </div>
+                    `,
+                        },
+                    }),
+
+                ]);
+
+                search.start();
+
+            })
+        }
+    }
+}(Drupal, drupalSettings, once));

--- a/modules/quant_search/quant_search.info.yml
+++ b/modules/quant_search/quant_search.info.yml
@@ -1,0 +1,11 @@
+name: Quant Search
+description: 'Allows creation of Quant Search pages.'
+package: Quant
+
+type: module
+core_version_requirement: ^8 || ^9
+core: 8.x
+
+dependencies:
+  - drupal:quant
+  - drupal:quant_api

--- a/modules/quant_search/quant_search.libraries.yml
+++ b/modules/quant_search/quant_search.libraries.yml
@@ -1,0 +1,14 @@
+algolia:
+  css:
+    theme:
+      https://cdn.jsdelivr.net/npm/instantsearch.css@7/themes/algolia-min.css: { type: external, minified: true }
+      css/quant-search.css: {}
+  js:
+    https://cdn.jsdelivr.net/npm/algoliasearch@4/dist/algoliasearch-lite.umd.js: { type: external, minified: true }
+    https://cdn.jsdelivr.net/npm/instantsearch.js@4: { type: external, minified: true }
+    js/quant-search.js: {}
+  dependencies:
+    - core/drupal
+    - core/drupalSettings
+    - core/jquery.once
+    - core/once

--- a/modules/quant_search/quant_search.links.action.yml
+++ b/modules/quant_search/quant_search.links.action.yml
@@ -1,0 +1,11 @@
+entity.quant_search_page.add_form:
+  route_name: 'entity.quant_search_page.add_form'
+  title: 'Add Quant search page'
+  appears_on:
+    - entity.quant_search_page.collection
+
+entity.quant_search_page.clear_index:
+  route_name: 'quant_search.clear_index'
+  title: 'Clear index'
+  appears_on:
+    - quant_search.main

--- a/modules/quant_search/quant_search.links.menu.yml
+++ b/modules/quant_search/quant_search.links.menu.yml
@@ -1,0 +1,20 @@
+quant_search.main:
+  title: 'Quant Search'
+  route_name: quant_search.main
+  description: 'Manage Quant Search'
+  parent: quant
+  weight: 2
+
+entity.quant_search_page.collection:
+  title: 'Quant Search Pages'
+  route_name: entity.quant_search_page.collection
+  description: 'Manage Quant Search pages'
+  parent: quant_search.main
+  weight: 3
+
+quant_search.main.entities:
+  title: 'Quant Search Entities'
+  route_name: quant_search.main.entities
+  description: 'Manage Quant Search pages'
+  parent: quant_search.main
+  weight: 3

--- a/modules/quant_search/quant_search.links.task.yml
+++ b/modules/quant_search/quant_search.links.task.yml
@@ -1,0 +1,24 @@
+quant_search.main:
+  route_name: quant_search.main
+  title: 'Search'
+  base_route: quant.config
+
+quant_search.main.overview:
+  route_name: quant_search.main
+  title: 'Overview'
+  parent_id: quant_search.main
+
+entity.quant_search_page.collection:
+  route_name: entity.quant_search_page.collection
+  title: 'Pages'
+  parent_id: quant_search.main
+
+quant_search.main.main:
+  route_name: quant_search.main.index
+  title: 'Index'
+  parent_id: quant_search.main
+
+quant_search.main.entities:
+  route_name: quant_search.main.entities
+  title: 'Entity configuration'
+  parent_id: quant_search.main

--- a/modules/quant_search/quant_search.module
+++ b/modules/quant_search/quant_search.module
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * @file
+ * Quant Search module.
+ */
+
+use Drupal\quant_search\Controller\Search;
+use Drupal\node\Entity\Node;
+use Drupal\quant\Event\QuantEvent;
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Implements hook_theme().
+ */
+function quant_search_theme($existing, $type, $theme, $path) {
+  return [
+    'search_page_status' => [
+      'variables' => [
+        'index' => NULL,
+        'settings' => NULL,
+        'pages' => NULL,
+      ],
+    ],
+    'search_page' => [
+      'variables' => [
+        'index' => NULL,
+        'page' => NULL,
+        'facets' => NULL,
+      ],
+    ],
+  ];
+}
+
+/**
+ * Process the queue.
+ *
+ * @param array $context
+ *   The batch context.
+ */
+function quant_search_run_index($nids, $languages, array &$context) {
+
+  $client = \Drupal::service('quant_api.client');
+  $config = \Drupal::config('quant_search.entities.settings');
+
+  // Add the latest node to the batch.
+  if (empty($context['sandbox'])) {
+    $context['sandbox']['progress'] = 0;
+    $context['sandbox']['current_number'] = 0;
+    $context['sandbox']['total'] = count($nids);
+  }
+
+  $records = [];
+  foreach ($nids as $idx => $nid) {
+    $node = Node::load($nid);
+
+    // Multilang support.
+    $filter = [];
+
+    if (!empty($languages)) {
+      $filter = array_filter($languages);
+    }
+
+    foreach ($node->getTranslationLanguages() as $langcode => $language) {
+      if (!empty($filter) && !in_array($langcode, $filter)) {
+        continue;
+      }
+
+      $node = $node->getTranslation($langcode);
+      if ($node->isPublished()) {
+        $records[] = Search::generateSearchRecord($node, $langcode);
+      }
+
+    }
+    $context['sandbox']['progress']++;
+  }
+
+  $client->sendSearchRecords($records);
+
+  $context['message'] = t('Processed @i of @t', [
+    '@i' => $context['sandbox']['progress'],
+    '@t' => $context['sandbox']['total'],
+  ]);
+
+  if ($context['sandbox']['progress'] != $context['sandbox']['total']) {
+    $context['finished'] = $context['sandbox']['progress'] / $context['sandbox']['total'];
+  }
+
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_delete().
+ */
+function quant_search_quant_search_page_delete(EntityInterface $entity) {
+  $route = $entity->get('route');
+  \Drupal::service('event_dispatcher')->dispatch(QuantEvent::UNPUBLISH, new QuantEvent('', $route, [], NULL));
+}

--- a/modules/quant_search/quant_search.permissions.yml
+++ b/modules/quant_search/quant_search.permissions.yml
@@ -1,0 +1,6 @@
+administer quant search:
+  title: 'Administer quant search'
+use quant search:
+  title: 'Use quant search'
+clear quant search index:
+  title: 'Clear the search index'

--- a/modules/quant_search/quant_search.routing.yml
+++ b/modules/quant_search/quant_search.routing.yml
@@ -1,0 +1,75 @@
+quant_search.main:
+  path: '/admin/config/development/quant/search'
+  defaults:
+    _controller: '\Drupal\quant_search\Controller\Search::statusPage'
+    _title: 'Quant Search'
+  requirements:
+    _permission: 'administer quant search'
+  options:
+    _admin_route: TRUE
+
+quant_search.main.index:
+  path: '/admin/config/development/quant/search/index'
+  defaults:
+    _form: '\Drupal\quant_search\Form\SearchIndexForm'
+    _title: 'Quant Search Index'
+  requirements:
+    _permission: 'administer quant search'
+  options:
+    _admin_route: TRUE
+
+entity.quant_search_page.collection:
+  path: '/admin/config/development/quant/search/pages'
+  defaults:
+    _entity_list: 'quant_search_page'
+    _title: 'Quant Search Pages'
+  requirements:
+    _permission: 'administer quant search'
+  options:
+    _admin_route: TRUE
+
+entity.quant_search_page.add_form:
+  path: '/admin/config/development/quant/search/pages/add'
+  defaults:
+    _entity_form: 'quant_search_page.add'
+    _title: 'Add Quant search page'
+  requirements:
+    _permission: 'administer quant search'
+
+entity.quant_search_page.edit_form:
+  path: '/admin/config/development/quant/search/pages/{quant_search_page}'
+  defaults:
+    _entity_form: 'quant_search_page.edit'
+    _title: 'Edit Quant search page'
+  requirements:
+    _permission: 'administer quant search'
+
+entity.quant_search_page.delete_form:
+  path: '/admin/config/development/quant/search/pages/{quant_search_page}/delete'
+  defaults:
+    _entity_form: 'quant_search_page.delete'
+    _title: 'Delete Quant search page'
+  requirements:
+    _permission: 'administer quant search'
+
+quant_search.main.entities:
+  path: '/admin/config/development/quant/search/entities'
+  defaults:
+    _form: '\Drupal\quant_search\Form\SearchEntitiesForm'
+    _title: 'Quant Search Entities'
+  requirements:
+    _permission: 'administer quant search'
+  options:
+    _admin_route: TRUE
+
+quant_search.clear_index:
+  path: '/admin/config/development/quant/search/clear'
+  defaults:
+    _form: '\Drupal\quant_search\Form\ConfirmIndexClearForm'
+    _title: 'Confirm Index clear'
+  requirements:
+    _permission: 'clear quant search index'
+
+
+route_callbacks:
+    - '\Drupal\quant_search\Routing\QuantSearchRoutes::searchPageRoutes'

--- a/modules/quant_search/quant_search.services.yml
+++ b/modules/quant_search/quant_search.services.yml
@@ -1,0 +1,12 @@
+services:
+  quant_search.search_page_repository:
+    class: Drupal\quant_search\SearchPageRepository
+    arguments: ['@config.factory', '@entity_type.manager']
+
+  quant_search.output.api:
+    class: Drupal\quant_search\EventSubscriber\SearchEventSubscriber
+    arguments:
+      - '@logger.factory'
+      - '@event_dispatcher'
+    tags:
+      - { name: 'event_subscriber' }

--- a/modules/quant_search/src/Controller/Search.php
+++ b/modules/quant_search/src/Controller/Search.php
@@ -1,0 +1,365 @@
+<?php
+
+namespace Drupal\quant_search\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\quant_api\Client\QuantClientInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\node\Entity\Node;
+use Drupal\Core\Url;
+use Drupal\quant\Seed;
+
+/**
+ * Quant configuration form.
+ *
+ * @see Drupal\Core\Form\ConfigFormBase
+ */
+class Search extends ControllerBase {
+
+  const SETTINGS = 'quant_api.settings';
+
+  /**
+   * Build the form.
+   */
+  public function __construct(QuantClientInterface $client) {
+    $this->client = $client;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('quant_api.client')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function statusPage() {
+    $config = $this->config(self::SETTINGS);
+
+    if ($config->get('api_token')) {
+      if ($project = $this->client->project()) {
+        if ($project->config->search_enabled) {
+          $message = t('Search is enabled for @api', ['@api' => $config->get('api_project')]);
+          \Drupal::messenger()->addMessage($message);
+        }
+        else {
+          \Drupal::messenger()->addError(t('Search is not enabled for this project. Enable via the Quant Dashboard.'));
+        }
+      }
+      else {
+        \Drupal::messenger()->addError(t('Unable to connect to Quant API, check settings.'));
+      }
+    }
+
+    // Retrieve search stats.
+    $search = $this->client->search();
+
+    if (!isset($search->index)) {
+      return [
+        '#markup' => $this->t('Unable to retrieve search index values.'),
+      ];
+    }
+
+    return [
+      '#theme' => 'search_page_status',
+      '#index' => $search->index,
+      '#settings' => $search->settings,
+      '#pages' => NULL,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function searchPage($page) {
+
+    $project = $this->client->project();
+
+    $languages = $page->get('languages');
+    $bundles = $page->get('bundles');
+    $manualFilters = $page->get('manual_filters');
+    $facets = $page->get('facets');
+    unset($facets['actions']);
+
+    $facetKeys = self::processTranslatedFacetKeys($facets);
+
+    $filters = [];
+
+    if (!empty($languages)) {
+      $filters[] = "(lang_code:'" . implode('\' OR lang_code:\'', $languages) . "')";
+    }
+
+    if (!empty($bundles)) {
+      $filters[] = "(content_type:'" . implode('\' OR content_type:\'', $bundles) . "')";
+    }
+
+    if (!empty($manualFilters)) {
+      $filters[] = $manualFilters;
+    }
+
+    $filtersString = implode(' AND ', $filters);
+
+    return [
+      '#theme' => 'search_page',
+      '#attached' => [
+        'library' => [
+          'quant_search/algolia',
+        ],
+        'drupalSettings' => [
+          'quantSearch' => [
+            'algolia_application_id' => $project->config->search_index->algolia_application_id,
+            'algolia_read_key' => $project->config->search_index->algolia_read_key,
+            'algolia_index' => $project->config->search_index->algolia_index,
+            'filters' => $filtersString,
+            'facets' => $facetKeys,
+            'display' => $page->get('display'),
+          ],
+        ],
+      ],
+      '#index' => $project->config->search_index,
+      '#page' => $page->toArray(),
+      '#facets' => $facetKeys,
+    ];
+  }
+
+  /**
+   * Generate the search record for an entity.
+   */
+  public static function generateSearchRecord($entity, $langcode = NULL) {
+
+    $config = \Drupal::config('quant_search.entities.settings');
+
+    // Bail if entity is undefined.
+    if (empty($entity)) {
+      return;
+    }
+
+    $entityType = $entity->getEntityTypeId();
+    if (!empty($langcode)) {
+      $entity = $entity->getTranslation($langcode);
+    }
+    else {
+      $langcode = $entity->language()->getId();
+    }
+
+    // Get override values.
+    $typeConfig = \Drupal::config('quant_search.entities.settings.' . $entity->bundle());
+
+    // Determine whether this entity should be skipped.
+    $skipRecord = FALSE;
+    $nodeEnabled = $config->get('quant_search_entity_node');
+    $taxonomyEnabled = $config->get('quant_search_entity_taxonomy_term');
+
+    if ($entity->getEntityTypeId() == 'node' && !$nodeEnabled) {
+      $skipRecord = TRUE;
+    }
+
+    // Skip if 'exclude' is set on this type.
+    if (!empty($typeConfig) && $typeConfig->get('exclude')) {
+      $skipRecord = TRUE;
+    }
+
+    // Determine whether language should be skipped.
+    $allowedLanguage = $config->get('quant_search_entity_node_languages');
+
+    if (!empty($allowedLanguage)) {
+      $allowedLanguage = array_filter($allowedLanguage);
+      if (!empty($allowedLanguage)) {
+        if (!in_array($langcode, $allowedLanguage)) {
+          $skipRecord = TRUE;
+        }
+      }
+    }
+
+    // Determine whether the search record should be created or skipped.
+    $allowedBundles = $config->get('quant_search_entity_node_bundles');
+
+    if (!empty($allowedBundles)) {
+      $allowedBundles = array_filter($allowedBundles);
+      if (!empty($allowedBundles)) {
+        if (!in_array($entity->bundle(), $allowedBundles)) {
+          $skipRecord = TRUE;
+        }
+      }
+    }
+
+    // Skip search record.
+    if ($skipRecord) {
+      $record = [
+        'skip' => TRUE,
+      ];
+      return $record;
+    }
+
+    // Get default values.
+    $titleToken = $config->get('quant_search_title_token');
+    $summaryToken = $config->get('quant_search_summary_token');
+    $imageToken = $config->get('quant_search_image_token');
+    $viewMode = $config->get('quant_search_content_viewmode');
+
+    if (!empty($typeConfig) && $typeConfig->get('enabled')) {
+      $titleToken = $typeConfig->get('quant_search_title_token');
+      $summaryToken = $typeConfig->get('quant_search_summary_token');
+      $imageToken = $typeConfig->get('quant_search_image_token');
+      $viewMode = $typeConfig->get('quant_search_content_viewmode');
+    }
+
+    // Get token values from context.
+    $ctx = [];
+    $ctx[$entityType] = $entity;
+
+    $title = \Drupal::token()->replace($titleToken, $ctx, [
+      'langcode' => $langcode,
+      'clear' => TRUE,
+    ]);
+    $summary = \Drupal::token()->replace($summaryToken, $ctx, [
+      'langcode' => $langcode,
+      'clear' => TRUE,
+    ]);
+    $image = \Drupal::token()->replace($imageToken, $ctx, [
+      'langcode' => $langcode,
+      'clear' => TRUE,
+    ]);
+
+    $view_builder = \Drupal::entityTypeManager()->getViewBuilder($entityType);
+    $build = $view_builder->view($entity, $viewMode, $langcode);
+    $output = \Drupal::service('renderer')->renderRoot($build);
+
+    $record = [];
+
+    if (!empty($title)) {
+      $record['title'] = $title;
+    }
+
+    if (!empty($summary)) {
+      $record['summary'] = strip_tags(html_entity_decode($summary));
+    }
+
+    if (!empty($output)) {
+      $record['content'] = strip_tags(html_entity_decode($output));
+    }
+
+    if (!empty($image)) {
+      $record['image'] = strip_tags(html_entity_decode($image));
+      // Rewrite images as relative paths.
+      $record['image'] = Seed::rewriteRelative($record['image']);
+    }
+
+    $options = ['absolute' => FALSE];
+    if (!empty($langcode)) {
+      $language = \Drupal::languageManager()->getLanguage($langcode);
+      $options['language'] = $language;
+      $record['lang_code'] = $langcode;
+
+      foreach ($entity->getTranslationLanguages() as $code => $l) {
+        $language_label = \Drupal::service('string_translation')->translate($language->getName(), [], ['langcode' => $code]);
+        $record["language_${code}"] = $language_label;
+      }
+    }
+
+    // @todo Node only logic..
+    $record['url'] = Url::fromRoute('entity.node.canonical', ['node' => $entity->id()], $options)->toString();
+
+    // Add search meta for node entities.
+    if ($entity->getEntityTypeId() == 'node') {
+      $record += self::getNodeTerms($entity, $langcode);
+      $record["content_type"] = $entity->type->entity->id();
+
+      $translated_type = \Drupal::service('string_translation')->translate($entity->type->entity->label(), [], ['langcode' => $langcode]);
+      $record["content_type_{$langcode}"] = $translated_type;
+    }
+
+    return $record;
+  }
+
+  /**
+   * Retrieves any terms attached to a given node.
+   *
+   * @param Drupal\node\Entity\Node $entity
+   *   The entity to gather info for.
+   * @param string $langcode
+   *   The language code for the entity.
+   *
+   * @return array
+   *   Terms tagged to the node.
+   */
+  private static function getNodeTerms(Node $entity, $langcode) {
+    $query = \Drupal::database()
+      ->select('taxonomy_index', 'ti')
+      ->fields('ti', ['tid'])
+      ->condition('nid', $entity->id());
+
+    $results = $query->execute()->fetchCol();
+
+    $tids = \Drupal::entityTypeManager()
+      ->getStorage('taxonomy_term')
+      ->loadMultiple($results);
+
+    $terms = [];
+
+    foreach ($tids as $term) {
+      $entity = $term->getTranslation($langcode);
+      $key = $term->bundle() . '_' . $langcode;
+      $terms[$key][] = $entity->label();
+    }
+
+    return $terms;
+  }
+
+  /**
+   * Determine translated facet keys.
+   *
+   * @param array $facets
+   *   The facets array attached to the custom entity.
+   *
+   * @return array
+   *   The processed array.
+   */
+  public static function processTranslatedFacetKeys(array $facets) {
+
+    $keys = [];
+    foreach ($facets as $k => $f) {
+      $lang = $f['facet_language'];
+
+      switch ($f['facet_type']) {
+        case "taxonomy":
+          $key = $f['taxonomy_vocabulary'] . '_' . $lang;
+          $containerKey = $key . "_{$k}";
+          $f['facet_key'] = $key;
+          $f['facet_container'] = $containerKey;
+          $keys[$containerKey] = $f;
+          break;
+
+        case "content_type":
+          $key = "content_type_{$lang}";
+          $containerKey = $key . "_{$k}";
+          $f['facet_key'] = $key;
+          $f['facet_container'] = $containerKey;
+          $keys[$containerKey] = $f;
+          break;
+
+        case "language":
+          $key = "language_{$lang}";
+          $containerKey = $key . "_{$k}";
+          $f['facet_key'] = $key;
+          $f['facet_container'] = $containerKey;
+          $keys[$containerKey] = $f;
+          break;
+
+        case "custom":
+          // @todo This
+          break;
+
+        default:
+          // Nada.
+      }
+    }
+
+    return $keys;
+  }
+
+}

--- a/modules/quant_search/src/Entity/QuantSearchPage.php
+++ b/modules/quant_search/src/Entity/QuantSearchPage.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Drupal\quant_search\Entity;
+
+use Drupal\Core\Config\Entity\ConfigEntityBase;
+use Drupal\quant_search\QuantSearchPageInterface;
+
+/**
+ * Defines the quant_search_page entity type.
+ *
+ * @ConfigEntityType(
+ *   id = "quant_search_page",
+ *   label = @Translation("Quant Search Page"),
+ *   label_collection = @Translation("Quant Search Pages"),
+ *   label_singular = @Translation("Quant Search Page"),
+ *   label_plural = @Translation("Quant Search Pages"),
+ *   label_count = @PluralTranslation(
+ *     singular = "@count quant_search_page",
+ *     plural = "@count quant_search_pages",
+ *   ),
+ *   handlers = {
+ *     "list_builder" = "Drupal\quant_search\QuantSearchPageListBuilder",
+ *     "form" = {
+ *       "add" = "Drupal\quant_search\Form\QuantSearchPageForm",
+ *       "edit" = "Drupal\quant_search\Form\QuantSearchPageForm",
+ *       "delete" = "Drupal\Core\Entity\EntityDeleteForm"
+ *     }
+ *   },
+ *   config_prefix = "quant_search",
+ *   admin_permission = "administer quant search",
+ *   links = {
+ *     "collection" = "/admin/config/development/quant/search/pages",
+ *     "add-form" = "/admin/config/development/quant/search/pages/add",
+ *     "edit-form" = "/admin/config/development/quant/search/pages/{quant_search_page}",
+ *     "delete-form" = "/admin/config/development/quant/search/pages/{quant_search_page}/delete"
+ *   },
+ *   entity_keys = {
+ *     "id" = "id",
+ *     "label" = "label",
+ *     "uuid" = "uuid",
+ *     "route" = "route",
+ *     "title" = "title",
+ *     "description" = "description",
+ *     "languages" = "languages",
+ *     "bundles" = "bundles",
+ *     "manual_filters" = "manual_filters",
+ *     "facets" = "facets",
+ *     "display" = "display"
+ *   },
+ *   config_export = {
+ *     "id",
+ *     "label",
+ *     "description",
+ *     "route",
+ *     "title",
+ *     "description",
+ *     "languages",
+ *     "bundles",
+ *     "manual_filters",
+ *     "facets",
+ *     "display"
+ *   }
+ * )
+ */
+class QuantSearchPage extends ConfigEntityBase implements QuantSearchPageInterface {
+
+  /**
+   * The quant_search_page ID.
+   *
+   * @var string
+   */
+  protected $id;
+
+  /**
+   * The quant_search_page label.
+   *
+   * @var string
+   */
+  protected $label;
+
+  /**
+   * The quant_search_page title.
+   *
+   * @var string
+   */
+  protected $title;
+
+  /**
+   * The quant_search_page status.
+   *
+   * @var bool
+   */
+  protected $status;
+
+  /**
+   * The quant_search_page description.
+   *
+   * @var string
+   */
+  protected $description;
+
+  /**
+   * The quant_search_page route.
+   *
+   * @var string
+   */
+  protected $route;
+
+  /**
+   * The languages to filter.
+   *
+   * @var array
+   */
+  protected $languages = [];
+
+  /**
+   * The bundles to filter.
+   *
+   * @var array
+   */
+  protected $bundles = [];
+
+  /**
+   * Manual filter string.
+   *
+   * @var string
+   */
+  protected $manual_filters;
+
+  /**
+   * Facets.
+   *
+   * @var array
+   */
+  protected $facets = [];
+
+  /**
+   * Display configuration.
+   *
+   * @var array
+   */
+  protected $display = [];
+
+}

--- a/modules/quant_search/src/EventSubscriber/SearchEventSubscriber.php
+++ b/modules/quant_search/src/EventSubscriber/SearchEventSubscriber.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Drupal\quant_search\EventSubscriber;
+
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher;
+use Drupal\quant\Event\QuantEvent;
+use Drupal\quant_search\Controller\Search;
+
+/**
+ * Inject search_record object during push.
+ */
+class SearchEventSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The logger.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   */
+  protected $logger;
+
+  /**
+   * The event dispatcher.
+   *
+   * @var \Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher
+   */
+  protected $eventDispatcher;
+
+  /**
+   * Search event subscriber.
+   *
+   * Listens to Quant events and updates search_record data.
+   *
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
+   *   The logger channel factory.
+   * @param \Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher $event_dispatcher
+   *   The event dispatcher.
+   */
+  public function __construct(LoggerChannelFactoryInterface $logger_factory, ContainerAwareEventDispatcher $event_dispatcher) {
+    $this->logger = $logger_factory->get('quant_search');
+    $this->eventDispatcher = $event_dispatcher;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[QuantEvent::OUTPUT] = ['onOutput', 1];
+    return $events;
+  }
+
+  /**
+   * Push search_record object based on configuration.
+   *
+   * @param Drupal\quant\Event\QuantEvent $event
+   *   The event.
+   */
+  public function onOutput(QuantEvent $event) {
+    $entity = $event->getEntity();
+    $meta = $event->getMetadata();
+    $langcode = $event->getLangcode();
+    $meta['search_record'] = Search::generateSearchRecord($entity, $langcode);
+    $event->setMetadata($meta);
+  }
+
+}

--- a/modules/quant_search/src/Form/ConfirmIndexClearForm.php
+++ b/modules/quant_search/src/Form/ConfirmIndexClearForm.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Drupal\quant_search\Form;
+
+use Drupal\Core\Form\ConfirmFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+
+/**
+ * Defines a confirmation form to confirm deletion of something by id.
+ */
+class ConfirmIndexClearForm extends ConfirmFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, string $id = NULL) {
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $client = \Drupal::service('quant_api.client');
+    $client->clearSearchIndex();
+    $form_state->setRedirect('quant_search.main');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() : string {
+    return "confirm_delete_form";
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl() {
+    return new Url('quant_search.main');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion() {
+    return $this->t('Do you want to clear the search index?');
+  }
+
+}

--- a/modules/quant_search/src/Form/QuantSearchPageForm.php
+++ b/modules/quant_search/src/Form/QuantSearchPageForm.php
@@ -1,0 +1,459 @@
+<?php
+
+namespace Drupal\quant_search\Form;
+
+use Drupal\Core\Entity\EntityForm;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\taxonomy\Entity\Vocabulary;
+use Drupal\quant_search\Controller\Search;
+use Drupal\quant\Plugin\QueueItem\RouteItem;
+use Drupal\quant\Event\QuantEvent;
+
+/**
+ * Form handler for the Quant Search page add and edit forms.
+ */
+class QuantSearchPageForm extends EntityForm {
+
+  /**
+   * Constructs an QuantSearchPageForm object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entityTypeManager.
+   */
+  public function __construct(EntityTypeManagerInterface $entityTypeManager) {
+    $this->entityTypeManager = $entityTypeManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function form(array $form, FormStateInterface $form_state) {
+    $form = parent::form($form, $form_state);
+
+    $page = $this->entity;
+
+    $form['#tree'] = TRUE;
+
+    $form['label'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Label'),
+      '#maxlength' => 255,
+      '#default_value' => $page->label(),
+      '#description' => $this->t("Administrative label for the search page."),
+      '#required' => TRUE,
+    ];
+
+    $form['id'] = [
+      '#type' => 'machine_name',
+      '#default_value' => $page->id(),
+      '#machine_name' => [
+        'exists' => [$this, 'exist'],
+      ],
+      '#disabled' => !$page->isNew(),
+    ];
+
+    $form['status'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enabled'),
+      '#default_value' => $this->entity->status(),
+    ];
+
+    $form['title'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Title'),
+      '#maxlength' => 255,
+      '#default_value' => $this->entity->get('title'),
+      '#description' => $this->t("Page title."),
+    ];
+
+    $form['description'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Description'),
+      '#default_value' => $this->entity->get('description'),
+      '#description' => $this->t('Search page description.'),
+    ];
+
+    $languages = \Drupal::languageManager()->getLanguages();
+
+    if (count($languages) > 1) {
+      $defaultLanguage = \Drupal::languageManager()->getDefaultLanguage();
+      $language_codes = [];
+
+      foreach ($languages as $langcode => $language) {
+        $default = ($defaultLanguage->getId() == $langcode) ? ' (Default)' : '';
+        $language_codes[$langcode] = $language->getName() . $default;
+      }
+
+      $form['languages'] = [
+        '#type' => 'select',
+        '#title' => $this->t('Languages'),
+        '#description' => $this->t('Optionally restrict to these languages. If no options are selected all languages will be included.'),
+        '#options' => $language_codes,
+        '#default_value' => $this->entity->get('languages'),
+        '#multiple' => TRUE,
+      ];
+    }
+
+    // Seed by bundle.
+    $types = \Drupal::entityTypeManager()
+      ->getStorage('node_type')
+      ->loadMultiple();
+
+    $content_types = [];
+    foreach ($types as $type) {
+      $content_types[$type->id()] = $type->label();
+    }
+
+    $form['bundles'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Enabled bundles'),
+      '#description' => $this->t('Optionally restrict to these content types.'),
+      '#options' => $content_types,
+      '#default_value' => $this->entity->get('bundles'),
+      '#multiple' => TRUE,
+    ];
+
+    $form['manual_filters'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Manual Filters'),
+      '#maxlength' => 2048,
+      '#default_value' => $this->entity->get('manual_filters'),
+      '#description' => $this->t('Optionally provide complex filters. For example: <code>cost>10 AND cost<99.5</code>. You may join with ANDs, ORs.'),
+    ];
+
+    $form['route'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Route'),
+      '#maxlength' => 255,
+      '#default_value' => $this->entity->get('route'),
+      '#description' => $this->t('Page route for the search page.'),
+      '#required' => TRUE,
+    ];
+
+    $existingDisplayConfig = $this->entity->get('display');
+
+    // Form state facets trump the entity state.
+    $vals = $form_state->getValues();
+    if (!empty($vals['display'])) {
+      $existingDisplayConfig = $vals['display'];
+    }
+
+    $form['display'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Display options'),
+      '#prefix' => '<div id="display-fieldset-wrapper">',
+      '#suffix' => '</div>',
+    ];
+
+    $form['display']['results'] = [
+      '#type' => 'details',
+      '#open' => FALSE,
+      '#title' => $this->t('Results display'),
+    ];
+
+    $form['display']['results']['display_search'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Display search textfield'),
+      '#default_value' => $existingDisplayConfig['results']['display_search'] ?? TRUE,
+    ];
+
+    $form['display']['results']['display_stats'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Display stats'),
+      '#description' => $this->t('e.g number of hits/results for a query'),
+      '#default_value' => $existingDisplayConfig['results']['display_stats'] ?? TRUE,
+    ];
+
+    $form['display']['results']['show_clear_refinements'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Display clear refinements button'),
+      '#default_value' => $existingDisplayConfig['results']['show_clear_refinements'] ?? TRUE,
+    ];
+
+    $form['display']['pagination'] = [
+      '#type' => 'details',
+      '#open' => FALSE,
+      '#title' => $this->t('Pagination options'),
+    ];
+
+    $form['display']['pagination']['pagination_enabled'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Pagination enabled'),
+      '#default_value' => $existingDisplayConfig['pagination']['pagination_enabled'] ?? TRUE,
+    ];
+
+    $form['display']['pagination']['per_page'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Hits per page'),
+      '#default_value' => $existingDisplayConfig['pagination']['per_page'] ?? 20,
+    ];
+
+    $form['facets'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Facets'),
+      '#prefix' => '<div id="facets-fieldset-wrapper">',
+      '#suffix' => '</div>',
+    ];
+
+    // Retrieve facets attached to the entity.
+    $existingFacets = $this->entity->get('facets');
+    $existingDisplayConfig = $this->entity->get('display');
+
+    // Form state facets trump the entity state.
+    $vals = $form_state->getValues();
+    if (!empty($vals['facets'])) {
+      $existingFacets = $vals['facets'];
+    }
+    else {
+      $existingFacets[] = [];
+    }
+
+    foreach ($existingFacets as $i => $facet) {
+
+      $form['facets'][$i] = [
+        '#type' => 'details',
+        '#open' => TRUE,
+        '#title' => $this->t('Facet configuration'),
+      ];
+
+      $types = [
+        'taxonomy' => 'Taxonomy',
+        'content_type' => 'Content type',
+        'language' => 'Language',
+        'custom' => 'Custom',
+      ];
+
+      $displayTypes = [
+        'checkbox' => "Checkbox (multi select)",
+        'select' => "Select list (single select)",
+        'menu' => "Menu list (single select)",
+      ];
+
+      $form['facets'][$i]['facet_display'] = [
+        '#type' => 'select',
+        '#title' => $this->t('Facet type'),
+        '#options' => $displayTypes,
+        '#default_value' => $facet['facet_display'],
+        '#attributes' => [
+          'id' => "facet_{$i}_display_type",
+        ],
+      ];
+
+      $form['facets'][$i]['facet_type'] = [
+        '#type' => 'select',
+        '#title' => $this->t('Facet type'),
+        '#options' => $types,
+        '#default_value' => $facet['facet_type'],
+        '#attributes' => [
+          'id' => "facet_{$i}_type",
+        ],
+      ];
+
+      $vocabularies = Vocabulary::loadMultiple();
+
+      $vocab_options = [];
+      foreach ($vocabularies as $vocab) {
+        $vocab_options[$vocab->id()] = $vocab->label();
+      }
+
+      $form['facets'][$i]['taxonomy_vocabulary'] = [
+        '#type' => 'select',
+        '#title' => t('Taxonomy vocabulary'),
+        '#options' => $vocab_options,
+        '#default_value' => $facet['taxonomy_vocabulary'],
+        '#states' => [
+          'visible' => [
+            ':input[id="facet_' . $i . '_type"]' => ['value' => 'taxonomy'],
+          ],
+        ],
+      ];
+
+      $form['facets'][$i]['custom_key'] = [
+        '#type' => 'textfield',
+        '#title' => t('Custom key'),
+        '#description' => t('Provide a custom key as defined in your entity token configuration'),
+        '#default_value' => $facet['custom_key'],
+        '#states' => [
+          'visible' => [
+            ':input[id="facet_' . $i . '_type"]' => ['value' => 'custom'],
+          ],
+        ],
+      ];
+
+      $form['facets'][$i]['facet_heading'] = [
+        '#type' => 'textfield',
+        '#title' => t('Facet heading'),
+        '#default_value' => $facet['facet_heading'],
+      ];
+
+      $languages = \Drupal::languageManager()->getLanguages();
+      $defaultLanguage = \Drupal::languageManager()->getDefaultLanguage();
+      $language_codes = [];
+
+      foreach ($languages as $langcode => $language) {
+        $default = ($defaultLanguage->getId() == $langcode) ? ' (Default)' : '';
+        $language_codes[$langcode] = $language->getName() . $default;
+      }
+
+      $form['facets'][$i]['facet_language'] = [
+        '#type' => 'select',
+        '#title' => $this->t('Facet language'),
+        '#description' => $this->t('Language to use for the facet.'),
+        '#options' => $language_codes,
+        '#default_value' => $facet['facet_language'],
+      ];
+
+      $form['facets'][$i]['actions']['remove_facet'] = [
+        '#type' => 'submit',
+        '#value' => t('Remove facet'),
+        '#name' => 'remove_facet_' . $i,
+        '#index' => $i,
+        '#submit' => ['::removeCallback'],
+        '#ajax' => [
+          'callback' => '::addmoreCallback',
+          'wrapper' => 'facets-fieldset-wrapper',
+        ],
+      ];
+    }
+
+    // Add "add facet" button to last item in the array.
+    $form['facets'][$i]['actions']['add_facet'] = [
+      '#type' => 'submit',
+      '#value' => t('Add facet'),
+      '#submit' => ['::addOne'],
+      '#ajax' => [
+        'callback' => '::addmoreCallback',
+        'wrapper' => 'facets-fieldset-wrapper',
+      ],
+    ];
+
+    $form_state->setCached(FALSE);
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function save(array $form, FormStateInterface $form_state) {
+
+    unset($form['facets']['actions']);
+    $page = $this->entity;
+    $status = $page->save();
+
+    if ($status === SAVED_NEW) {
+      $this->messenger()->addMessage($this->t('The %label search page created.', [
+        '%label' => $page->label(),
+      ]));
+    }
+    else {
+      $this->messenger()->addMessage($this->t('The %label search page updated.', [
+        '%label' => $page->label(),
+      ]));
+    }
+
+    // Ensure API is aware of facets and enable as required.
+    $facets = $form_state->getValue(['facets']);
+    unset($facets['actions']);
+
+    $keys = Search::processTranslatedFacetKeys($facets);
+
+    $uniqKeys = [];
+
+    // Add default filters (lang_code/bundle).
+    $uniqKeys[] = 'lang_code';
+    $uniqKeys[] = 'content_type';
+
+    foreach ($keys as $k) {
+      if (!isset($uniqKeys[$k['facet_key']])) {
+        $uniqKeys[] = $k['facet_key'];
+      }
+    }
+
+    if (!empty($keys)) {
+      $client = \Drupal::service('quant_api.client');
+      $client->addFacets($uniqKeys);
+    }
+
+    \Drupal::service('router.builder')->rebuild();
+
+    // Seed the route in Quant.
+    $published = $form_state->getValue('status');
+    $route = $form_state->getValue('route');
+
+    if ($published) {
+      $item = new RouteItem(['route' => $route]);
+      $item->send();
+    }
+    else {
+      \Drupal::service('event_dispatcher')->dispatch(QuantEvent::UNPUBLISH, new QuantEvent('', $route, [], NULL));
+    }
+
+    $form_state->setRedirect('entity.quant_search_page.collection');
+  }
+
+  /**
+   * Helper function to check if a search page configuration entity exists.
+   */
+  public function exist($id) {
+    $entity = $this->entityTypeManager->getStorage('quant_search_page')->getQuery()
+      ->condition('id', $id)
+      ->execute();
+    return (bool) $entity;
+  }
+
+  /**
+   * Adds one more facet to the form.
+   */
+  public function addOne(array &$form, FormStateInterface $form_state) {
+    $vals = $form_state->getValues();
+    $vals['facets'][] = [];
+    $form_state->setValues($vals);
+    $form_state->setRebuild();
+  }
+
+  /**
+   * Callback: Add more facet form group.
+   */
+  public function addmoreCallback(array &$form, FormStateInterface $form_state) {
+    return $form['facets'];
+  }
+
+  /**
+   * Callback: Remove facet form group.
+   */
+  public function removeCallback(array &$form, FormStateInterface $form_state) {
+    $values = $form_state->getValues();
+    $element = $form_state->getTriggeringElement();
+
+    // Remove based on item index.
+    if (!isset($element['#index'])) {
+      return;
+    }
+
+    $idx = $element['#index'];
+    if (isset($values['facets'][$idx])) {
+      unset($values['facets'][$idx]);
+    }
+
+    // Facets are empty, add a new blank item.
+    if (empty($values['facets'])) {
+      $values['facets'][] = [];
+    }
+
+    $form_state->setValues($values);
+    $form_state->setRebuild();
+  }
+
+}

--- a/modules/quant_search/src/Form/SearchEntitiesForm.php
+++ b/modules/quant_search/src/Form/SearchEntitiesForm.php
@@ -1,0 +1,303 @@
+<?php
+
+namespace Drupal\quant_search\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\quant_api\Client\QuantClientInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Quant configuration form.
+ *
+ * @see Drupal\Core\Form\ConfigFormBase
+ */
+class SearchEntitiesForm extends ConfigFormBase {
+
+  const SETTINGS = 'quant_search.entities.settings';
+
+  /**
+   * Build the form.
+   */
+  public function __construct(QuantClientInterface $client) {
+    $this->client = $client;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('quant_api.client')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'quant_search.entities';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEditableConfigNames() {
+    return [
+      self::SETTINGS,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config(self::SETTINGS);
+
+    if ($config->get('api_token')) {
+      if ($project = $this->client->project()) {
+        if ($project->config->search_enabled) {
+          $message = t('Search is enabled for @api', ['@api' => $config->get('api_project')]);
+          \Drupal::messenger()->addMessage($message);
+        }
+        else {
+          \Drupal::messenger()->addError(t('Search is not enabled for this project. Enable via the Quant Dashboard.'));
+        }
+      }
+      else {
+        \Drupal::messenger()->addError(t('Unable to connect to Quant API, check settings.'));
+      }
+    }
+
+    $form['quant_search_entity_node'] = [
+      '#type' => 'checkbox',
+      '#default_value' => $config->get('quant_search_entity_node'),
+      '#title' => $this->t('Nodes'),
+      '#description' => $this->t('Keep search records for nodes updated.'),
+    ];
+
+    $form['node_details'] = [
+      '#type' => 'details',
+      '#tree' => FALSE,
+      '#title' => $this->t('Node configuration'),
+      '#states' => [
+        'visible' => [
+          ':input[name="quant_search_entity_node"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+
+    // Seed by language.
+    // Only active if there are more than one active languages.
+    $languages = \Drupal::languageManager()->getLanguages();
+
+    if (count($languages) > 1) {
+      $defaultLanguage = \Drupal::languageManager()->getDefaultLanguage();
+      $language_codes = [];
+
+      foreach ($languages as $langcode => $language) {
+        $default = ($defaultLanguage->getId() == $langcode) ? ' (Default)' : '';
+        $language_codes[$langcode] = $language->getName() . $default;
+      }
+
+      $form['node_details']['quant_search_entity_node_languages'] = [
+        '#type' => 'checkboxes',
+        '#title' => $this->t('Languages'),
+        '#description' => $this->t('Optionally restrict to these languages. If no options are selected all languages will have a search record created.'),
+        '#options' => $language_codes,
+        '#default_value' => $config->get('quant_search_entity_node_languages') ?: [],
+      ];
+    }
+
+    // Get node bundles.
+    $types = \Drupal::entityTypeManager()
+      ->getStorage('node_type')
+      ->loadMultiple();
+
+    $content_types = [];
+    foreach ($types as $type) {
+      $content_types[$type->id()] = $type->label();
+    }
+
+    $node_view_modes = [];
+    foreach (\Drupal::service('entity_display.repository')->getViewModes('node') as $k => $vm) {
+      $node_view_modes[$k] = $vm['label'];
+    }
+
+    $form['node_details']['quant_search_entity_node_bundles'] = [
+      '#type' => 'checkboxes',
+      '#title' => $this->t('Enabled bundles'),
+      '#description' => $this->t('Optionally restrict to these content types.'),
+      '#options' => $content_types,
+      '#default_value' => $config->get('quant_search_entity_node_bundles') ?: [],
+    ];
+
+    $form['quant_search_entity_taxonomy_term'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Taxonomy terms'),
+      '#description' => $this->t('Keep search records for taxonomy terms updated.'),
+      '#default_value' => $config->get('quant_search_entity_taxonomy_term'),
+    ];
+
+    $form['search_tokens_node'] = [
+      '#type' => 'vertical_tabs',
+      '#states' => [
+        'visible' => [
+          ':input[name="quant_search_entity_node"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+
+    $form['search_tokens_node_default'] = [
+      '#type' => 'details',
+      '#title' => 'Default',
+      '#group' => 'search_tokens_node',
+      '#tree' => TRUE,
+    ];
+
+    $form['search_tokens_node_default']['quant_search_title_token'] = [
+      '#type' => 'textfield',
+      '#title' => 'Title',
+      '#description' => 'Token to use for record title',
+      '#default_value' => $config->get('quant_search_title_token'),
+    ];
+
+    $form['search_tokens_node_default']['quant_search_summary_token'] = [
+      '#type' => 'textfield',
+      '#title' => 'Summary',
+      '#description' => 'Token to use for record summary',
+      '#default_value' => $config->get('quant_search_summary_token'),
+    ];
+
+    $form['search_tokens_node_default']['quant_search_image_token'] = [
+      '#type' => 'textfield',
+      '#title' => 'Image',
+      '#description' => 'Token to use for record image',
+      '#default_value' => $config->get('quant_search_image_token'),
+    ];
+
+    $form['search_tokens_node_default']['quant_search_content_viewmode'] = [
+      '#type' => 'select',
+      '#title' => 'Content view mode',
+      '#description' => 'View mode to render the content as for search body. Not used in display by default (search only value).',
+      '#default_value' => $config->get('quant_search_content_viewmode'),
+      '#options' => $node_view_modes,
+    ];
+
+    foreach ($types as $type) {
+
+      $tokenConfig = $this->config(self::SETTINGS . '.' . $type->id());
+
+      $form['search_tokens_node_' . $type->id()] = [
+        '#type' => 'details',
+        '#title' => $type->label(),
+        '#group' => 'search_tokens_node',
+        '#tree' => TRUE,
+      ];
+
+      $form['search_tokens_node_' . $type->id()]['exclude'] = [
+        '#type' => 'checkbox',
+        '#default_value' => $tokenConfig->get('exclude'),
+        '#title' => $this->t('Exclude'),
+        '#description' => $this->t('Excludes this type from the search index.'),
+      ];
+
+      $form['search_tokens_node_' . $type->id()]['enabled'] = [
+        '#type' => 'checkbox',
+        '#default_value' => $tokenConfig->get('enabled'),
+        '#title' => $this->t('Override'),
+        '#description' => $this->t('Override default node values.'),
+      ];
+
+      $form['search_tokens_node_' . $type->id()]['quant_search_title_token'] = [
+        '#type' => 'textfield',
+        '#title' => 'Title',
+        '#default_value' => $tokenConfig->get('quant_search_title_token'),
+        '#states' => [
+          'enabled' => [
+            ':input[name="search_tokens_node_' . $type->id() . '[enabled]"]' => ['checked' => TRUE],
+          ],
+        ],
+      ];
+
+      $form['search_tokens_node_' . $type->id()]['quant_search_summary_token'] = [
+        '#type' => 'textfield',
+        '#title' => 'Summary',
+        '#default_value' => $tokenConfig->get('quant_search_summary_token'),
+        '#states' => [
+          'enabled' => [
+            ':input[name="search_tokens_node_' . $type->id() . '[enabled]"]' => ['checked' => TRUE],
+          ],
+        ],
+      ];
+
+      $form['search_tokens_node_' . $type->id()]['quant_search_image_token'] = [
+        '#type' => 'textfield',
+        '#title' => 'Image',
+        '#default_value' => $tokenConfig->get('quant_search_image_token'),
+        '#states' => [
+          'enabled' => [
+            ':input[name="search_tokens_node_' . $type->id() . '[enabled]"]' => ['checked' => TRUE],
+          ],
+        ],
+      ];
+
+      $form['search_tokens_node_' . $type->id()]['quant_search_content_viewmode'] = [
+        '#type' => 'select',
+        '#title' => 'Content view mode',
+        '#description' => 'View mode to render the content as for search body',
+        '#default_value' => $tokenConfig->get('quant_search_content_viewmode'),
+        '#options' => $node_view_modes,
+        '#states' => [
+          'enabled' => [
+            ':input[name="search_tokens_node_' . $type->id() . '[enabled]"]' => ['checked' => TRUE],
+          ],
+        ],
+      ];
+    }
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+
+    $nodeTokens = $form_state->getValue('search_tokens_node_default');
+
+    // Retrieve the configuration.
+    $this->configFactory->getEditable(self::SETTINGS)
+      ->set('quant_search_title_token', $nodeTokens['quant_search_title_token'])
+      ->set('quant_search_entity_node', $form_state->getValue('quant_search_entity_node'))
+      ->set('quant_search_entity_node_languages', $form_state->getValue('quant_search_entity_node_languages'))
+      ->set('quant_search_entity_node_bundles', $form_state->getValue('quant_search_entity_node_bundles'))
+      ->set('quant_search_entity_taxonomy_term', $form_state->getValue('quant_search_entity_taxonomy_term'))
+      ->set('quant_search_summary_token', $nodeTokens['quant_search_summary_token'])
+      ->set('quant_search_image_token', $nodeTokens['quant_search_image_token'])
+      ->set('quant_search_content_viewmode', $nodeTokens['quant_search_content_viewmode'])
+      ->save();
+
+    // Iterate node type overrides.
+    $types = \Drupal::entityTypeManager()
+      ->getStorage('node_type')
+      ->loadMultiple();
+
+    $content_types = [];
+    foreach ($types as $type) {
+      $typeTokens = $form_state->getValue('search_tokens_node_' . $type->id());
+
+      $typeConfig = $this->configFactory->getEditable(self::SETTINGS . '.' . $type->id())
+        ->set('exclude', $typeTokens['exclude'])
+        ->set('enabled', $typeTokens['enabled'])
+        ->set('quant_search_title_token', $typeTokens['quant_search_title_token'])
+        ->set('quant_search_summary_token', $typeTokens['quant_search_summary_token'])
+        ->set('quant_search_image_token', $typeTokens['quant_search_image_token'])
+        ->set('quant_search_content_viewmode', $typeTokens['quant_search_content_viewmode'])
+        ->save();
+    }
+
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/modules/quant_search/src/Form/SearchIndexForm.php
+++ b/modules/quant_search/src/Form/SearchIndexForm.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Drupal\quant_search\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\quant_api\Client\QuantClientInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Quant configuration form.
+ *
+ * @see Drupal\Core\Form\ConfigFormBase
+ */
+class SearchIndexForm extends ConfigFormBase {
+
+  const SETTINGS = 'quant_search.index.settings';
+
+  /**
+   * Build the form.
+   */
+  public function __construct(QuantClientInterface $client) {
+    $this->client = $client;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('quant_api.client')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'quant_search.entities';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEditableConfigNames() {
+    return [
+      self::SETTINGS,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config(self::SETTINGS);
+
+    if ($config->get('api_token')) {
+      if ($project = $this->client->project()) {
+        if ($project->config->search_enabled) {
+          $message = t('Search is enabled for @api', ['@api' => $config->get('api_project')]);
+          \Drupal::messenger()->addMessage($message);
+        }
+        else {
+          \Drupal::messenger()->addError(t('Search is not enabled for this project. Enable via the Quant Dashboard.'));
+        }
+      }
+      else {
+        \Drupal::messenger()->addError(t('Unable to connect to Quant API, check settings.'));
+      }
+    }
+
+    $form['quant_search_index_entity_node'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Nodes'),
+      '#description' => $this->t('Reindex nodes.'),
+    ];
+
+    $form['node_details'] = [
+      '#type' => 'details',
+      '#tree' => FALSE,
+      '#title' => $this->t('Node configuration'),
+      '#states' => [
+        'visible' => [
+          ':input[name="quant_search_index_entity_node"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+
+    // Seed by language.
+    // Only active if there are more than one active languages.
+    $languages = \Drupal::languageManager()->getLanguages();
+
+    if (count($languages) > 1) {
+      $defaultLanguage = \Drupal::languageManager()->getDefaultLanguage();
+      $language_codes = [];
+
+      foreach ($languages as $langcode => $language) {
+        $default = ($defaultLanguage->getId() == $langcode) ? ' (Default)' : '';
+        $language_codes[$langcode] = $language->getName() . $default;
+      }
+
+      $form['node_details']['quant_search_index_entity_node_languages'] = [
+        '#type' => 'checkboxes',
+        '#title' => $this->t('Languages'),
+        '#description' => $this->t('Optionally restrict to these languages. If no options are selected all languages will be exported.'),
+        '#options' => $language_codes,
+      ];
+    }
+
+    // Seed by bundle.
+    $types = \Drupal::entityTypeManager()
+      ->getStorage('node_type')
+      ->loadMultiple();
+
+    $content_types = [];
+    foreach ($types as $type) {
+      $content_types[$type->id()] = $type->label();
+    }
+
+    $form['node_details']['quant_search_index_entity_node_bundles'] = [
+      '#type' => 'checkboxes',
+      '#title' => $this->t('Enabled bundles'),
+      '#description' => $this->t('Optionally restrict to these content types.'),
+      '#options' => $content_types,
+    ];
+
+    $form['quant_search_index_entity_taxonomy_term'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Taxonomy terms'),
+      '#description' => $this->t('Exports taxonomy term pages.'),
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+
+    $query = \Drupal::entityQuery('node')
+      ->condition('status', 1);
+
+    $bundles = $form_state->getValue('quant_search_index_entity_node_bundles');
+
+    if (!empty($bundles)) {
+      $bundles = array_filter($bundles);
+      if (!empty($bundles)) {
+        $query->condition('type', array_keys($bundles), 'IN');
+      }
+    }
+
+    $nids = $query->execute();
+
+    // Chunk into a few batches.
+    $batches = array_chunk($nids, 50);
+
+    $batch = [
+      'title' => $this->t('Exporting to Quant...'),
+      'operations' => [],
+      'init_message'     => $this->t('Commencing'),
+      'progress_message' => $this->t('Processed @current out of @total.'),
+      'error_message'    => $this->t('An error occurred during processing'),
+    ];
+
+    // Filter by language.
+    $languages = $form_state->getValue('quant_search_index_entity_node_languages');
+
+    foreach ($batches as $b) {
+      $batch['operations'][] = ['quant_search_run_index', [$b, $languages]];
+    }
+
+    batch_set($batch);
+
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/modules/quant_search/src/Form/SearchPagesForm.php
+++ b/modules/quant_search/src/Form/SearchPagesForm.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Drupal\quant_search\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\quant_api\Client\QuantClientInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Quant configuration form.
+ *
+ * @see Drupal\Core\Form\ConfigFormBase
+ */
+class SearchPagesForm extends ConfigFormBase {
+
+  const SETTINGS = 'quant_api.settings';
+
+  /**
+   * Build the form.
+   */
+  public function __construct(QuantClientInterface $client) {
+    $this->client = $client;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('quant_api.client')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'quant_api_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEditableConfigNames() {
+    return [
+      self::SETTINGS,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config(self::SETTINGS);
+
+    $form = [];
+
+    if ($config->get('api_token')) {
+      if ($project = $this->client->project()) {
+        if ($project->config->search_enabled) {
+          $message = t('Search is enabled for @api', ['@api' => $config->get('api_project')]);
+          \Drupal::messenger()->addMessage($message);
+        }
+        else {
+          \Drupal::messenger()->addError(t('Search is not enabled for this project. Enable via the Quant Dashboard.'));
+          return parent::buildForm($form, $form_state);
+        }
+      }
+      else {
+        \Drupal::messenger()->addError(t('Unable to connect to Quant API, check settings.'));
+        return parent::buildForm($form, $form_state);
+      }
+    }
+
+    return parent::buildForm($form, $form_state);
+  }
+
+}

--- a/modules/quant_search/src/QuantSearchPageInterface.php
+++ b/modules/quant_search/src/QuantSearchPageInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Drupal\quant_search;
+
+use Drupal\Core\Config\Entity\ConfigEntityInterface;
+
+/**
+ * Provides an interface defining a Quant Search page entity.
+ */
+interface QuantSearchPageInterface extends ConfigEntityInterface {
+
+}

--- a/modules/quant_search/src/QuantSearchPageListBuilder.php
+++ b/modules/quant_search/src/QuantSearchPageListBuilder.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Drupal\quant_search;
+
+use Drupal\Core\Config\Entity\ConfigEntityListBuilder;
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Provides a listing of Quant Search page.
+ */
+class QuantSearchPageListBuilder extends ConfigEntityListBuilder {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildHeader() {
+    $header['label'] = $this->t('Quant Search pages');
+    $header['id'] = $this->t('Machine name');
+    $header['enabled'] = $this->t('Enabled');
+    $header['route'] = $this->t('Route');
+    return $header + parent::buildHeader();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildRow(EntityInterface $entity) {
+    $row['label'] = $entity->label();
+    $row['id'] = $entity->id();
+    $row['enabled'] = $entity->status();
+    $row['route'] = $entity->get('route');
+    return $row + parent::buildRow($entity);
+  }
+
+}

--- a/modules/quant_search/src/Routing/QuantSearchRoutes.php
+++ b/modules/quant_search/src/Routing/QuantSearchRoutes.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Drupal\quant_search\Routing;
+
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Class EntityOverview.
+ *
+ * @package Drupal\quant_search\Routing
+ */
+class QuantSearchRoutes {
+
+  /**
+   * Dynamically generate the routes for the entity details.
+   *
+   * @return \Symfony\Component\Routing\RouteCollection
+   *   The search page routes.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function searchPageRoutes() {
+    $collection = new RouteCollection();
+
+    $storage = \Drupal::entityTypeManager()->getStorage('quant_search_page');
+    $ids = \Drupal::entityQuery('quant_search_page')->execute();
+    $pages = $storage->loadMultiple($ids);
+
+    foreach ($pages as $page) {
+
+      if (!$page->get('status')) {
+        continue;
+      }
+
+      $route = new Route(
+            $page->get('route'),
+            [
+              '_title' => $page->get('title'),
+              '_controller' => '\Drupal\quant_search\Controller\Search::searchPage',
+              'page' => $page,
+            ],
+            [
+              '_permission' => 'access content',
+            ]
+        );
+      $collection->add("entity.quant_search_page.{$page->id()}", $route);
+    }
+    return $collection;
+  }
+
+}

--- a/modules/quant_search/templates/search-page-status.html.twig
+++ b/modules/quant_search/templates/search-page-status.html.twig
@@ -1,0 +1,21 @@
+<h2>Quant Search status</h2>
+
+<h4>Index status</h4>
+<table>
+<tbody>
+    <th>Records</th>
+    <th>Data size</th>
+    <th>File size</th>
+    <th>Pending tasks</th>
+    <th>Index name</th>
+    <th>Last updated</th>
+    <tr>
+        <td>{{ index.entries }}</td>
+        <td>{{ index.dataSize }}</td>
+        <td>{{ index.fileSize }}</td>
+        <td>{{ index.numberOfPendingTasks }}</td>
+        <td>{{ index.name }}</td>
+        <td>{{ index.updatedAt }}</td>
+    </tr>
+    </tbody>
+</table>

--- a/modules/quant_search/templates/search-page.html.twig
+++ b/modules/quant_search/templates/search-page.html.twig
@@ -1,0 +1,39 @@
+<div class="quant-search">
+
+    {%if page.description %}
+    <h4>{{ page.description }}</h4>
+    {% endif %}
+
+    <div class="flex-grid">
+
+        {% if facets is not empty %}
+        <div class="col facets">
+            {% if page.display.results.show_clear_refinements %}
+            <div id="clear-refinements"></div>
+            {% endif %}
+
+            {% for facet in facets %}
+            <div class="facet-container">
+                <div class="facet-heading">{{ facet.facet_heading }}</div>
+                <div id="facet_{{ facet.facet_container }}"></div>
+            </div>
+            {% endfor %}
+        </div>
+        {% endif %}
+
+        <div class="col content">
+            {% if page.display.results.display_search %}
+            <div id="searchbox" class="ais-SearchBox"></div>
+            {% endif %}
+
+            {% if page.display.results.display_stats %}
+            <div id="stats"></div>
+            {% endif %}
+            <div id="hits"></div>
+
+            {% if page.display.pagination.pagination_enabled %}
+            <div id="pagination"></div>
+            {% endif %}
+        </div>
+    </div>
+</div>

--- a/quant.module
+++ b/quant.module
@@ -68,7 +68,7 @@ function quant_node_update(EntityInterface $entity) {
   // If entity default revision is unpublished then unpublish in quant.
   if (!$entity->isPublished() && $entity->isDefaultRevision()) {
     // Trigger an unpublish event.
-    Seed::unpublishRoute($entity);
+    Seed::unpublishNode($entity);
   }
 
   // Exclude draft revisions from Quant if enabled.
@@ -234,13 +234,15 @@ function quant_redirect_delete($redirect) {
  */
 function _quant_entity_update_op(EntityInterface $entity) {
 
+  $langcode = $entity->language()->getId();
+
   switch ($entity->getEntityTypeId()) {
     case 'node':
-      Seed::seedNode($entity);
+      Seed::seedNode($entity, $langcode);
       break;
 
     case 'taxonomy_term':
-      Seed::seedTaxonomyTerm($entity);
+      Seed::seedTaxonomyTerm($entity, $langcode);
       break;
   }
 
@@ -261,7 +263,21 @@ function _quant_entity_delete_op(EntityInterface $entity) {
     return;
   }
 
-  Seed::unpublishRoute($entity);
+  Seed::unpublishNode($entity);
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_translation_delete().
+ */
+function quant_node_translation_delete($entity) {
+  $quant_enabled = \Drupal::config('quant.settings')->get('quant_enabled');
+  $quant_node_enabled = \Drupal::config('quant.settings')->get('quant_enabled_nodes');
+
+  if (!$quant_enabled || !$quant_node_enabled) {
+    return;
+  }
+
+  Seed::unpublishNode($entity);
 }
 
 /**

--- a/src/Event/QuantEvent.php
+++ b/src/Event/QuantEvent.php
@@ -67,13 +67,29 @@ final class QuantEvent extends Event {
   protected $rid;
 
   /**
+   * The entity itself.
+   *
+   * @var Drupal\Core\Entity\EntityInterface
+   */
+  protected $entity;
+
+  /**
+   * The langcode associated with the event.
+   *
+   * @var string
+   */
+  protected $langcode;
+
+  /**
    * {@inheritdoc}
    */
-  public function __construct($contents, $location, $meta, $rid = NULL) {
+  public function __construct($contents, $location, $meta, $rid = NULL, $entity = NULL, $langcode = NULL) {
     $this->contents = $contents;
     $this->location = $location;
     $this->meta = $meta;
     $this->rid = $rid;
+    $this->entity = $entity;
+    $this->langcode = $langcode;
   }
 
   /**
@@ -107,6 +123,16 @@ final class QuantEvent extends Event {
   }
 
   /**
+   * Get the langcode associated with the event.
+   *
+   * @return string
+   *   The langcode.
+   */
+  public function getLangcode() {
+    return $this->langcode;
+  }
+
+  /**
    * Get the metadata associated with the event.
    *
    * @return array
@@ -114,6 +140,20 @@ final class QuantEvent extends Event {
    */
   public function getMetadata() {
     return $this->meta;
+  }
+
+  /**
+   * Set the metadata associated with the event.
+   */
+  public function setMetadata($meta) {
+    $this->meta = $meta;
+  }
+
+  /**
+   * Entity getter.
+   */
+  public function getEntity() {
+    return $this->entity;
   }
 
 }

--- a/src/Plugin/MetadataBase.php
+++ b/src/Plugin/MetadataBase.php
@@ -65,7 +65,7 @@ abstract class MetadataBase extends PluginBase implements MetadataInterface {
    */
   public function getConfig($key = '') {
     $default = $this->defaultConfiguration();
-    return isset($this->config[$key]) ? $this->config[$key] : $default[$key];
+    return $this->config[$key] ?? $default[$key];
   }
 
   /**

--- a/src/Plugin/Quant/Metadata/Info.php
+++ b/src/Plugin/Quant/Metadata/Info.php
@@ -93,8 +93,16 @@ class Info extends MetadataBase implements ContainerFactoryPluginInterface {
   /**
    * {@inheritdoc}
    */
-  public function build(EntityInterface $entity) : array {
+  public function build(EntityInterface $entity, $langcode = NULL) : array {
     $meta = ['info' => []];
+
+    if (!empty($langcode)) {
+      $language = \Drupal::languageManager()->getLanguage($langcode);
+      $options['language'] = $language;
+    }
+    else {
+      $langcode = $entity->language()->getId();
+    }
 
     $author = $entity->getRevisionUser();
     $ctx[$entity->getEntityTypeId()] = $entity;
@@ -104,7 +112,10 @@ class Info extends MetadataBase implements ContainerFactoryPluginInterface {
     $ctx['user'] = $author;
 
     if (!empty($this->getConfig('author_name'))) {
-      $meta['info']['author_name'] = $this->token->replace($this->getConfig('author_name'), $ctx);
+      $meta['info']['author_name'] = $this->token->replace($this->getConfig('author_name'), $ctx, [
+        'langcode' => $langcode,
+        'clear' => TRUE,
+      ]);
     }
 
     $meta['content_timestamp'] = intval($date);
@@ -118,10 +129,13 @@ class Info extends MetadataBase implements ContainerFactoryPluginInterface {
     }
 
     // Add search meta for node entities.
+    // @todo these will all need translating..
     if ($entity->getEntityTypeId() == 'node') {
       $meta['search_record']['categories'] = $this->getNodeTerms($entity);
       $meta['search_record']['categories']['content_type'] = $entity->type->entity->label();
     }
+
+    $meta['search_record']['lang_code'] = $langcode;
 
     return $meta;
   }

--- a/src/Plugin/QueueItem/FileItem.php
+++ b/src/Plugin/QueueItem/FileItem.php
@@ -23,8 +23,8 @@ class FileItem implements QuantQueueItemInterface {
    */
   public function __construct(array $data = []) {
     $this->file = $data['file'];
-    $this->url = isset($data['url']) ? $data['url'] : NULL;
-    $this->fullPath = isset($data['full_path']) ? $data['full_path'] : NULL;
+    $this->url = $data['url'] ?? NULL;
+    $this->fullPath = $data['full_path'] ?? NULL;
   }
 
   /**

--- a/src/Plugin/QueueItem/NodeItem.php
+++ b/src/Plugin/QueueItem/NodeItem.php
@@ -38,7 +38,7 @@ class NodeItem implements QuantQueueItemInterface {
    */
   public function __construct(array $data = []) {
     $this->id = $data['id'];
-    $this->vid = isset($data['vid']) ? $data['vid'] : FALSE;
+    $this->vid = $data['vid'] ?? FALSE;
     $this->filter = isset($data['lang_filter']) && is_array($data['lang_filter']) ? array_filter($data['lang_filter']) : [];
   }
 

--- a/src/Plugin/QueueItem/RouteItem.php
+++ b/src/Plugin/QueueItem/RouteItem.php
@@ -23,7 +23,7 @@ class RouteItem implements QuantQueueItemInterface {
    * {@inheritdoc}
    */
   public function __construct(array $data = []) {
-    $route = isset($data['route']) ? $data['route'] : NULL;
+    $route = $data['route'] ?? NULL;
 
     if (!is_string($route)) {
       throw new \UnexpectedValueException(self::class . ' requires a string value.');
@@ -62,7 +62,7 @@ class RouteItem implements QuantQueueItemInterface {
       return;
     }
 
-    list($markup, $content_type) = $response;
+    [$markup, $content_type] = $response;
 
     $config = \Drupal::config('quant.settings');
     $proxy_override = boolval($config->get('proxy_override', FALSE));


### PR DESCRIPTION
This module allows a user to configure Quant Search completely within Drupal.

* Creation of Search Pages
* Configuration of facets (taxonomy, content type, language, or custom)
* Configuration of index (tokens per entity) and allows for custom fields/content schemas
* Custom filter application for more advanced use cases
* Optional pagination
* Optional results stats
* Clear and reindex directly