### PR TITLE
[ISSUE-49] Add option for stripping host domain.

### DIFF
--- a/src/Form/ConfigForm.php
+++ b/src/Form/ConfigForm.php
@@ -133,6 +133,13 @@ class ConfigForm extends ConfigFormBase {
       '#default_value' => $config->get('host_domain'),
     ];
 
+    $form['host_domain_strip'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Strip host domain from content'),
+      '#description' => $this->t('Optionally strip out the host domain above from any generated content. This includes body content and header metadata such as canonical links. If disabled, check your content is using relative links as expected.'),
+      '#default_value' => $config->get('host_domain_strip'),
+    ];
+
     $form['ssl_cert_verify'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Verify SSL certificates'),
@@ -157,6 +164,7 @@ class ConfigForm extends ConfigFormBase {
       ->set('proxy_override', $form_state->getValue('proxy_override'))
       ->set('local_server', $form_state->getValue('local_server'))
       ->set('host_domain', $form_state->getValue('host_domain'))
+      ->set('host_domain_strip', $form_state->getValue('host_domain_strip'))
       ->set('disable_content_drafts', $form_state->getValue('disable_content_drafts'))
       ->set('ssl_cert_verify', $form_state->getValue('ssl_cert_verify'))
       ->set('xpath_selectors', $form_state->getValue('xpath_selectors'))

--- a/src/Seed.php
+++ b/src/Seed.php
@@ -403,12 +403,22 @@ class Seed {
    */
   public static function rewriteRelative($markup) {
     $config = \Drupal::config('quant.settings');
+
+    // Do not strip host domain unless configured.
+    $strip = $config->get('host_domain_strip') ?: FALSE;
+    if (!$strip) {
+      return $markup;
+    }
+
+    // Strip the host domain from everywhere in the content including header
+    // metadata such as canonical links.
     $hostname = $config->get('host_domain') ?: $_SERVER['SERVER_NAME'];
     $port = $_SERVER['SERVER_PORT'];
     $markup = preg_replace("/(https?:\/\/)?{$hostname}(\:{$port})?/i", '', $markup);
 
     // Edge case: Replace http://default when run via drush without base_url.
     $markup = preg_replace("/http:\/\/default/i", '', $markup);
+
     return $markup;
   }
 


### PR DESCRIPTION
Adds a new configuration option:

<img width="659" alt="Screen Shot 2022-06-29 at 6 08 59 PM" src="https://user-images.githubusercontent.com/282024/176571402-5e8151df-b130-4fee-bced-cb3b95707d77.png">

that defaults to disabled.

In `Seed.php`, if disabled, the domain stripping won't happen.

The easiest way to manually test this is to add the domain into body content and save it and see if it's it strip out. Alternatively, you can check the canonical link to see if the domain is stripped out when enabled.

<img width="428" alt="Screen Shot 2022-06-29 at 6 12 15 PM" src="https://user-images.githubusercontent.com/282024/176571681-dc1f3df0-1b6f-4c9b-944a-7c792a708d3b.png">

