### PR TITLE
Added support for media oembed iframes.

### DIFF
--- a/modules/quant_api/src/EventSubscriber/QuantApi.php
+++ b/modules/quant_api/src/EventSubscriber/QuantApi.php
@@ -221,7 +221,7 @@ class QuantApi implements EventSubscriberInterface {
     }
 
     // Media oEmbed support.
-    // Core media may be embeded via an iFrame that is not included in the seed process.
+    // Core media may be embedded via iFrame not included by the seed process.
     // This content can be detected and included on the fly.
     /** @var \DOMElement $node */
     foreach ($xpath->query('//iframe[contains(@src, "/media/oembed")]') as $node) {

--- a/modules/quant_api/src/EventSubscriber/QuantApi.php
+++ b/modules/quant_api/src/EventSubscriber/QuantApi.php
@@ -220,6 +220,16 @@ class QuantApi implements EventSubscriberInterface {
       }
     }
 
+    // Media oEmbed support.
+    // Core media may be embeded via an iFrame that is not included in the seed process.
+    // This content can be detected and included on the fly.
+    /** @var \DOMElement $node */
+    foreach ($xpath->query('//iframe[contains(@src, "/media/oembed")]') as $node) {
+      $oembed_url = $new_href = $node->getAttribute('src');
+      $oembed_item = new RouteItem(['route' => $oembed_url]);
+      $oembed_item->send();
+    }
+
     // @todo Report on forms that need proxying (attachments.forms).
   }
 

--- a/src/Seed.php
+++ b/src/Seed.php
@@ -320,8 +320,11 @@ class Seed {
    */
   public static function markupFromRoute($route, array $headers = []) {
 
-    // Cleanse route.
-    $route = str_replace('//', '/', $route);
+    // Clean double slashes from routes.
+    // The exception is oEmbed routes which passes a full URL as query param.
+    if (!preg_match('/\/media\/oembed\?url=/', $route)) {
+      $route = str_replace('//', '/', $route);
+    }
 
     // Build internal request.
     $config = \Drupal::config('quant.settings');


### PR DESCRIPTION
D.o issue: https://www.drupal.org/project/quantcdn/issues/3311742

Drupal core supports remote video embed (YouTube/Vimeo).

These are rendered as iFrames rendered by Drupal (`/media/oembed?url=...`). The content of the iFrame is another iFrame that includes the actual video player.

This PR ensures the parent iFrame content is included in the content seed so these videos remain operational.