### PR TITLE
Quant Cron: Skip node_modules when syncing theme assets.

### DIFF
--- a/modules/quant_cron/quant_cron.module
+++ b/modules/quant_cron/quant_cron.module
@@ -179,7 +179,6 @@ function quant_cron_get_theme_routes() {
     if (preg_match('/node_modules/i', $name)) {
       continue;
     }
-    
     $path = str_replace(DRUPAL_ROOT, '', $name);
     $paths[] = $path;
   }

--- a/modules/quant_cron/quant_cron.module
+++ b/modules/quant_cron/quant_cron.module
@@ -175,6 +175,11 @@ function quant_cron_get_theme_routes() {
   $regex = new \RegexIterator($iterator, '/^.+(.jpe?g|.png|.svg|.ttf|.woff|.woff2|.otf|.ico|.js|.css)$/i', \RecursiveRegexIterator::GET_MATCH);
 
   foreach ($regex as $name => $r) {
+    // Skip node_modules.
+    if (preg_match('/node_modules/i', $name)) {
+      continue;
+    }
+    
     $path = str_replace(DRUPAL_ROOT, '', $name);
     $paths[] = $path;
   }


### PR DESCRIPTION
## Issue
Basically the same thing as was with #42 only now in Quant Cron module.
When seeding the site the module pulls node_modules folder in which is heavy and unnecessary - this slows down the sync.

## Solution
Seeing that node_modules is not required for static website this PR it has been explicitly skipped.

## Consideration
Should Quant Cron module rather use CollectEntitiesEvent? The code seems to be the same.