### PR TITLE
Strip DRUPAL_ROOT if already in the file path.

### DIFF
--- a/src/Plugin/QueueItem/FileItem.php
+++ b/src/Plugin/QueueItem/FileItem.php
@@ -53,6 +53,9 @@ class FileItem implements QuantQueueItemInterface {
       ]);
     }
 
+    // Ensure DRUPAL_ROOT prefix has not already been added.
+    $this->file = preg_replace('#^' . DRUPAL_ROOT . '#', '', $this->file);
+
     if (file_exists(DRUPAL_ROOT . $this->file)) {
       \Drupal::service('event_dispatcher')->dispatch(new QuantFileEvent(DRUPAL_ROOT . $this->file, $this->file), QuantFileEvent::OUTPUT);
     }


### PR DESCRIPTION
When adding files as custom routes in cron configuration (e.g `/themes/custom/quant_theme/images/rocket.png`) the `DRUPAL_ROOT` prefix is already added and has been through a round of `file_exists`.

This ensures we are just keeping the path consistent to other `FileItem` items.