### PR TITLE
Bail out of run-queue if another run is in progress.

### DIFF
--- a/src/Commands/QuantDrushCommands.php
+++ b/src/Commands/QuantDrushCommands.php
@@ -71,7 +71,7 @@ class QuantDrushCommands extends DrushCommands {
    *   Number of threads to use (default 5)
    * @usage quant:run-queue --threads=5
    * @option unlock
-   * Allow a queue run even if another run is in progress. (default is false)
+   *   Allow a queue run even if another run is in progress (default is false)
    * @usage quant:run-queue --unlock
    */
   public function message($options = ['threads' => 5, 'unlock' => false]) {
@@ -82,13 +82,14 @@ class QuantDrushCommands extends DrushCommands {
     $cmd = $drushPath . ' queue:run quant_seed_worker';
     $this->output()->writeln("<comment>Using drush binary at $drushPath. Override with \$DRUSH_PATH if required.</comment>");
 
-    // Bail if another run is in progress.
+    // If another seed is running and is locked, don't run this one.
     if (!$options['unlock']) {
       if (file_exists($lockFilePath)) {
-        $this->output()->writeln("<info>Seeding bailed. Another seed run is in progress.</info>");
+        $this->output()->writeln("<info>A seed is currently running and is locked which prevents another seed from running right now.</info>");
         return;
-      } else {
-        // No lock currently present. Create new lock file.
+      }
+      else {
+        // No lock file exists, so create one.
         file_put_contents($lockFilePath, null);
       }
     }

--- a/src/Commands/QuantDrushCommands.php
+++ b/src/Commands/QuantDrushCommands.php
@@ -70,11 +70,11 @@ class QuantDrushCommands extends DrushCommands {
    * @option threads
    *   Number of threads to use (default 5)
    * @usage quant:run-queue --threads=5
-   * @option bail
-   *  Bail out of a seed run if another run is in progress. (default is false)
-   * @usage quant:run-queue --bail
+   * @option unlock
+   * Allow a queue run even if another run is in progress. (default is false)
+   * @usage quant:run-queue --unlock
    */
-  public function message($options = ['threads' => 5, 'bail' => false]) {
+  public function message($options = ['threads' => 5, 'unlock' => false]) {
 
     $this->output()->writeln("<info>Forking seed worker.</info>");
     $drushPath = $this->getDrushPath();
@@ -82,13 +82,13 @@ class QuantDrushCommands extends DrushCommands {
     $cmd = $drushPath . ' queue:run quant_seed_worker';
     $this->output()->writeln("<comment>Using drush binary at $drushPath. Override with \$DRUSH_PATH if required.</comment>");
 
-    // Bail out if another run is in progress.
-    if ($options['bail']) {
+    // Bail if another run is in progress.
+    if (!$options['unlock']) {
       if (file_exists($lockFilePath)) {
         $this->output()->writeln("<info>Seeding bailed. Another seed run is in progress.</info>");
         return;
       } else {
-        // Create the new lock file.
+        // No lock currently present. Create new lock file.
         file_put_contents($lockFilePath, null);
       }
     }
@@ -107,7 +107,7 @@ class QuantDrushCommands extends DrushCommands {
     }
 
     // Remove lock file.
-    if ($options['bail']) {
+    if ($options['unlock']) {
       unlink($lockFilePath);
     }
 

--- a/src/Commands/QuantDrushCommands.php
+++ b/src/Commands/QuantDrushCommands.php
@@ -70,11 +70,8 @@ class QuantDrushCommands extends DrushCommands {
    * @option threads
    *   Number of threads to use (default 5)
    * @usage quant:run-queue --threads=5
-   * @option unlock
-   * Allow a queue run even if another run is in progress. (default is false)
-   * @usage quant:run-queue --unlock
    */
-  public function message($options = ['threads' => 5, 'unlock' => false]) {
+  public function message($options = ['threads' => 5]) {
 
     $this->output()->writeln("<info>Forking seed worker.</info>");
     $drushPath = $this->getDrushPath();
@@ -83,14 +80,12 @@ class QuantDrushCommands extends DrushCommands {
     $this->output()->writeln("<comment>Using drush binary at $drushPath. Override with \$DRUSH_PATH if required.</comment>");
 
     // Bail if another run is in progress.
-    if (!$options['unlock']) {
-      if (file_exists($lockFilePath)) {
-        $this->output()->writeln("<info>Seeding bailed. Another seed run is in progress.</info>");
-        return;
-      } else {
-        // No lock currently present. Create new lock file.
-        file_put_contents($lockFilePath, null);
-      }
+    if (file_exists($lockFilePath)) {
+      $this->output()->writeln("<info>Seeding bailed. Another seed run is in progress.</info>");
+      return;
+    } else {
+      // No lock currently present. Create new lock file.
+      file_put_contents($lockFilePath, null);
     }
 
     for ($i = 0; $i < $options['threads']; $i++) {
@@ -107,12 +102,24 @@ class QuantDrushCommands extends DrushCommands {
     }
 
     // Remove lock file.
-    if ($options['unlock']) {
-      unlink($lockFilePath);
-    }
+    unlink($lockFilePath);
 
     $this->output()->writeln("<info>Seeding complete.</info>");
 
+  }
+
+  /**
+   * Unlock quant queue.
+   *
+   * @command quant:unlock-queue
+   * @aliases quant-queue-unlock
+   * @usage quant:unlock-queue
+   */
+  public function unlock($options = []) {
+    $lockFilePath = sys_get_temp_dir() . '/quant_seed_worker.lock';
+    unlink($lockFilePath);
+
+    $this->output()->writeln("Unlocked Quant queue.");
   }
 
   /**


### PR DESCRIPTION
## Rationale
Consider a scenario where a site is using cron to run `quant:run-queue`, and the cron frequency is set to a fairly short time (e.g. 5 mins). Let's say there's also 1M nodes in the queue. With each new cron run the concurrency of jobs would pile up, potentially overwhelming the system.

## Proposed solution
Introduce a new option  `quant:run-queue --bail` that will check if another run is in progress, and if so, it will bail out of the current run.