### PR TITLE
Error on Quant Purger uninstall

### DIFF
--- a/modules/quant_purger/quant_purger.install
+++ b/modules/quant_purger/quant_purger.install
@@ -34,3 +34,18 @@ function quant_purger_schema() {
   ];
   return $schema;
 }
+
+/**
+ * Implements hook_uninstall().
+ */
+function quant_purger_uninstall() {
+  // Disable the plugin to prevent it from getting in a way of uninstall.
+  $plugins = \Drupal::service('purge.queuers')->getPluginsEnabled();
+  // Exclude Quant plugin from the list of all enabled plugins.
+  if (($key = array_search('quant', $plugins)) !== false) {
+    unset($plugins[$key]);
+  }
+
+  // Set enabled plugins, now excluding quant.
+  \Drupal::service('purge.queuers')->setPluginsEnabled($plugins);
+}

--- a/modules/quant_purger/quant_purger.install
+++ b/modules/quant_purger/quant_purger.install
@@ -36,6 +36,18 @@ function quant_purger_schema() {
 }
 
 /**
+ * Implements hook_install().
+ */
+function quant_purger_install() {
+  // Disable the plugin to prevent it from getting in a way of uninstall.
+  $plugins = \Drupal::service('purge.queuers')->getPluginsEnabled();
+  array_push($plugins, 'quant');
+
+  // Set enabled plugins, including quant.
+  \Drupal::service('purge.queuers')->setPluginsEnabled($plugins);
+}
+
+/**
  * Implements hook_uninstall().
  */
 function quant_purger_uninstall() {
@@ -48,4 +60,6 @@ function quant_purger_uninstall() {
 
   // Set enabled plugins, now excluding quant.
   \Drupal::service('purge.queuers')->setPluginsEnabled($plugins);
+  // Reset services to apply change.
+  \Drupal::service('kernel')->rebuildContainer();
 }


### PR DESCRIPTION
# Problem
When attempting to uninstall `quant_purger` module the site produces an error `SQLSTATE[42S02]: Base table or view not found`

# Context
Since the module hooks onto cache tags invalidation, it seems that it catches cache tag invalidations while in the process of module uninstall. At that point the database table is already removed, but Drupal services still have `quant_purger` registered in a service container, causing it to run `getPaths` method that attempts to query non-existent DB table.

# Proposed solution
Introduce `hook_install` and `hook_uninstall` to manually flip the status of the plugin on/off to prevent it from getting in the way. There may be other ways to resolve this (e.g. add some extra check in the plugin's `initialize`).