### PR TITLE
Add Facet values limit control

### DIFF
--- a/modules/quant_search/js/quant-search.js
+++ b/modules/quant_search/js/quant-search.js
@@ -119,7 +119,7 @@
                         snippetEllipsisText: '…',
                         filters: drupalSettings.quantSearch.filters,
                         hitsPerPage: drupalSettings.quantSearch.display.pagination.per_page,
-                        maxValuesPerFacet: drupalSettings.quantSearch.facets.max_values_number
+                        maxValuesPerFacet: drupalSettings.quantSearch.display.facets.max_values_number
                     }),
                     instantsearch.widgets.hits({
                         container: '#hits',

--- a/modules/quant_search/js/quant-search.js
+++ b/modules/quant_search/js/quant-search.js
@@ -118,7 +118,8 @@
                         attributesToSnippet: ['summary:100'],
                         snippetEllipsisText: '…',
                         filters: drupalSettings.quantSearch.filters,
-                        hitsPerPage: drupalSettings.quantSearch.display.pagination.per_page
+                        hitsPerPage: drupalSettings.quantSearch.display.pagination.per_page,
+                        maxValuesPerFacet: drupalSettings.quantSearch.facets.max_count
                     }),
                     instantsearch.widgets.hits({
                         container: '#hits',

--- a/modules/quant_search/js/quant-search.js
+++ b/modules/quant_search/js/quant-search.js
@@ -119,7 +119,7 @@
                         snippetEllipsisText: '…',
                         filters: drupalSettings.quantSearch.filters,
                         hitsPerPage: drupalSettings.quantSearch.display.pagination.per_page,
-                        maxValuesPerFacet: drupalSettings.quantSearch.facets.max_count
+                        maxValuesPerFacet: drupalSettings.quantSearch.facets.max_values_number
                     }),
                     instantsearch.widgets.hits({
                         container: '#hits',

--- a/modules/quant_search/js/quant-search.js
+++ b/modules/quant_search/js/quant-search.js
@@ -88,6 +88,7 @@
                                     instantsearch.widgets.refinementList({
                                         container: '#facet_' + facet.facet_container,
                                         attribute: facet.facet_key,
+                                        limit: facet.facet_limit,
                                     }),
                                 ]);
                                 break;
@@ -97,6 +98,7 @@
                                     instantsearch.widgets.menu({
                                         container: '#facet_' + facet.facet_container,
                                         attribute: facet.facet_key,
+                                        limit: facet.facet_limit,
                                     }),
                                 ]);
                                 break;
@@ -106,6 +108,7 @@
                                     instantsearch.widgets.menuSelect({
                                         container: '#facet_' + facet.facet_container,
                                         attribute: facet.facet_key,
+                                        limit: facet.facet_limit,
                                     }),
                                 ]);
                                 break;
@@ -118,8 +121,7 @@
                         attributesToSnippet: ['summary:100'],
                         snippetEllipsisText: '…',
                         filters: drupalSettings.quantSearch.filters,
-                        hitsPerPage: drupalSettings.quantSearch.display.pagination.per_page,
-                        maxValuesPerFacet: drupalSettings.quantSearch.display.facets.max_values_number
+                        hitsPerPage: drupalSettings.quantSearch.display.pagination.per_page
                     }),
                     instantsearch.widgets.hits({
                         container: '#hits',

--- a/modules/quant_search/quant_search.install
+++ b/modules/quant_search/quant_search.install
@@ -42,3 +42,25 @@ function quant_search_update_8102() {
   }
   return t('The token module is already installed.');
 }
+
+/**
+ * Add search page facet_limit configuration.
+ */
+function quant_search_update_8103() {
+  // Get all search pages.
+  $storage = \Drupal::entityTypeManager()->getStorage('quant_search_page');
+  $ids = \Drupal::entityQuery('quant_search_page')->execute();
+  $pages = $storage->loadMultiple($ids);
+
+  // Add default value for each facet, if not set.
+  foreach ($pages as $page) {
+    $facets = $page->get('facets');
+    foreach ($facets as $i => $facet) {
+      if (!isset($facet['facet_limit'])) {
+        $facets[$i]['facet_limit'] = 10;
+      }
+      $page->set('facets', $facets);
+    }
+    $page->save();
+  }
+}

--- a/modules/quant_search/src/Form/QuantSearchPageForm.php
+++ b/modules/quant_search/src/Form/QuantSearchPageForm.php
@@ -231,7 +231,7 @@ class QuantSearchPageForm extends EntityForm {
     $form['display']['facets']['max_values'] = [
       '#type' => 'number',
       '#title' => $this->t('Maximum number of facet values to return for each'),
-      '#default_value' => $existingDisplayConfig['facets']['max_values'] ?? 100,
+      '#default_value' => $existingDisplayConfig['facets']['max_values_number'] ?? 100,
     ];
 
     // Create tabledrag facets table.

--- a/modules/quant_search/src/Form/QuantSearchPageForm.php
+++ b/modules/quant_search/src/Form/QuantSearchPageForm.php
@@ -213,27 +213,6 @@ class QuantSearchPageForm extends EntityForm {
       '#default_value' => $existingDisplayConfig['pagination']['pagination_enabled'] ?? TRUE,
     ];
 
-    // Number of results per page.
-    $form['display']['pagination']['per_page'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Results per page'),
-      '#default_value' => $existingDisplayConfig['pagination']['per_page'] ?? 20,
-    ];
-    
-    // Facets display options.
-    $form['display']['facets'] = [
-      '#type' => 'details',
-      '#open' => FALSE,
-      '#title' => $this->t('Facets display'),
-    ];
-
-    // Max number of facet values to display.
-    $form['display']['facets']['max_values_number'] = [
-      '#type' => 'number',
-      '#title' => $this->t('Maximum number of facet values to return for each'),
-      '#default_value' => $existingDisplayConfig['facets']['max_values_number'] ?? 100,
-    ];
-
     // Create tabledrag facets table.
     $form['facets'] = [
       '#type' => 'table',
@@ -376,6 +355,12 @@ class QuantSearchPageForm extends EntityForm {
         '#title' => $this->t('Facet language'),
         '#options' => $language_codes,
         '#default_value' => $facet['facet_language'] ?? 'en',
+      ];
+      
+      $form['facets'][$i]['facet_limit'] = [
+        '#type' => 'number',
+        '#title' => $this->t('Facet limit'),
+        '#default_value' => $facet['facet_limit'] ?? 10,
       ];
 
       // Weight column element.

--- a/modules/quant_search/src/Form/QuantSearchPageForm.php
+++ b/modules/quant_search/src/Form/QuantSearchPageForm.php
@@ -213,6 +213,13 @@ class QuantSearchPageForm extends EntityForm {
       '#default_value' => $existingDisplayConfig['pagination']['pagination_enabled'] ?? TRUE,
     ];
 
+    // Number of results per page.
+    $form['display']['pagination']['per_page'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Results per page'),
+      '#default_value' => $existingDisplayConfig['pagination']['per_page'] ?? 20,
+    ];
+
     // Create tabledrag facets table.
     $form['facets'] = [
       '#type' => 'table',

--- a/modules/quant_search/src/Form/QuantSearchPageForm.php
+++ b/modules/quant_search/src/Form/QuantSearchPageForm.php
@@ -219,6 +219,20 @@ class QuantSearchPageForm extends EntityForm {
       '#title' => $this->t('Results per page'),
       '#default_value' => $existingDisplayConfig['pagination']['per_page'] ?? 20,
     ];
+    
+    // Facets display options.
+    $form['display']['facets'] = [
+      '#type' => 'details',
+      '#open' => FALSE,
+      '#title' => $this->t('Facets display'),
+    ];
+
+    // Max number of facet values to display.
+    $form['display']['facets']['max_values'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Maximum number of facet values to return for each'),
+      '#default_value' => $existingDisplayConfig['facets']['max_values'] ?? 100,
+    ];
 
     // Create tabledrag facets table.
     $form['facets'] = [

--- a/modules/quant_search/src/Form/QuantSearchPageForm.php
+++ b/modules/quant_search/src/Form/QuantSearchPageForm.php
@@ -228,7 +228,7 @@ class QuantSearchPageForm extends EntityForm {
     ];
 
     // Max number of facet values to display.
-    $form['display']['facets']['max_values'] = [
+    $form['display']['facets']['max_values_number'] = [
       '#type' => 'number',
       '#title' => $this->t('Maximum number of facet values to return for each'),
       '#default_value' => $existingDisplayConfig['facets']['max_values_number'] ?? 100,


### PR DESCRIPTION
# Problem
Algolia refinementList, menu and menuSelect widgets feature a `limit` property that defaults to `10`. This means that Quant Search facet widgets cannot show more values unless we override that default.

https://www.algolia.com/doc/api-reference/widgets/refinement-list/js/#widget-param-limit

# Proposed solution
Add a new form field when adding facets that allow users to specify the limit.

