### PR TITLE
[ISSUE-128] Handle edge case when file URL is empty.

### DIFF
--- a/modules/quant_file/quant_file.module
+++ b/modules/quant_file/quant_file.module
@@ -67,6 +67,14 @@ function quant_file_quant_seed_queue() {
 
   while ($file = $files->fetchAssoc()) {
     list($url, $context) = _quant_prepare_entity('file', $file['fid']);
+    if (empty($url)) {
+      quant_log('No URL found for file !fid',
+        array(
+          '!fid' => $file['fid'],
+        ),
+        WATCHDOG_WARNING);
+      continue;
+    }
     $item = array(
       'quant_seed',
       array($url, $context),


### PR DESCRIPTION
See d.o issue: https://www.drupal.org/project/quantcdn/issues/3339405

This is related to the empty file URI issue which might be a Drupal core bug.