### PR TITLE
[ISSUE-101] Handle canonical redirect when node is deleted.

### DIFF
--- a/modules/quant_search/src/Form/QuantSearchPageForm.php
+++ b/modules/quant_search/src/Form/QuantSearchPageForm.php
@@ -363,7 +363,7 @@ class QuantSearchPageForm extends EntityForm {
         '#options' => $language_codes,
         '#default_value' => $facet['facet_language'] ?? 'en',
       ];
-      
+
       $form['facets'][$i]['facet_limit'] = [
         '#type' => 'number',
         '#title' => $this->t('Facet limit'),

--- a/src/Seed.php
+++ b/src/Seed.php
@@ -102,6 +102,8 @@ class Seed {
    */
   public static function deleteRedirect($redirect) {
     $source = $redirect->getSourcePathWithQuery();
+    // QuantEvent can be used to unpublish any resource. Note, the source must
+    // be given here and not the destination.
     \Drupal::service('event_dispatcher')->dispatch(new QuantEvent('', $source, [], NULL), QuantEvent::UNPUBLISH);
   }
 
@@ -250,9 +252,16 @@ class Seed {
 
     $site_config = \Drupal::config('system.site');
     $front = $site_config->get('page.front');
-    if ((strpos($front, '/node/') === 0) && $entity->get('nid')->value == substr($front, 6)) {
+    if ((strpos($front, '/node/') === 0) && $nid == substr($front, 6)) {
       \Drupal::service('event_dispatcher')->dispatch(new QuantEvent('', '/', [], NULL), QuantEvent::UNPUBLISH);
     }
+
+   // Unpublish canonical redirects from node/123 to the unpublished revision route.
+   if ("/node/{$nid}" != $url) {
+     // QuantEvent can be used to unpublish any resource. Note, the source must
+     // be given here and not the destination.
+     \Drupal::service('event_dispatcher')->dispatch(new QuantEvent('', "/node/{$nid}", [], NULL), QuantEvent::UNPUBLISH);
+   }
 
     \Drupal::service('event_dispatcher')->dispatch(new QuantEvent('', $url, [], NULL), QuantEvent::UNPUBLISH);
   }

--- a/src/Seed.php
+++ b/src/Seed.php
@@ -256,12 +256,12 @@ class Seed {
       \Drupal::service('event_dispatcher')->dispatch(new QuantEvent('', '/', [], NULL), QuantEvent::UNPUBLISH);
     }
 
-   // Unpublish canonical redirects from node/123 to the unpublished revision route.
-   if ("/node/{$nid}" != $url) {
-     // QuantEvent can be used to unpublish any resource. Note, the source must
-     // be given here and not the destination.
-     \Drupal::service('event_dispatcher')->dispatch(new QuantEvent('', "/node/{$nid}", [], NULL), QuantEvent::UNPUBLISH);
-   }
+    // Unpublish canonical redirect from node/123.
+    if ("/node/{$nid}" != $url) {
+      // QuantEvent can be used to unpublish any resource. Note, the source must
+      // be given here and not the destination.
+      \Drupal::service('event_dispatcher')->dispatch(new QuantEvent('', "/node/{$nid}", [], NULL), QuantEvent::UNPUBLISH);
+    }
 
     \Drupal::service('event_dispatcher')->dispatch(new QuantEvent('', $url, [], NULL), QuantEvent::UNPUBLISH);
   }


### PR DESCRIPTION
See issue https://github.com/quantcdn/drupal/issues/101.

**Before node deletion:**

<img width="1163" alt="Screen Shot 2023-02-08 at 1 44 29 PM" src="https://user-images.githubusercontent.com/282024/217658394-8d0a0b10-9a36-4e38-8021-16b9f92d5e8b.png">

**After node deletion:**

<img width="1170" alt="Screen Shot 2023-02-08 at 1 45 14 PM" src="https://user-images.githubusercontent.com/282024/217658399-8bd2d784-cdfa-4d18-873b-5f5018c5e83f.png">
