### PR TITLE
[ISSUE-135] Unpublish term in Quant when unpublished or deleted in Drupal.

### DIFF
--- a/modules/quant_search/src/Form/QuantSearchPageForm.php
+++ b/modules/quant_search/src/Form/QuantSearchPageForm.php
@@ -363,7 +363,7 @@ class QuantSearchPageForm extends EntityForm {
         '#options' => $language_codes,
         '#default_value' => $facet['facet_language'] ?? 'en',
       ];
-      
+
       $form['facets'][$i]['facet_limit'] = [
         '#type' => 'number',
         '#title' => $this->t('Facet limit'),

--- a/quant.module
+++ b/quant.module
@@ -65,7 +65,7 @@ function quant_node_update(EntityInterface $entity) {
 
   $disable_drafts = \Drupal::config('quant.settings')->get('disable_content_drafts');
 
-  // If entity default revision is unpublished then unpublish in quant.
+  // If entity default revision is unpublished then unpublish in Quant.
   if (!$entity->isPublished() && $entity->isDefaultRevision()) {
     // Trigger an unpublish event.
     Seed::unpublishNode($entity);
@@ -112,6 +112,12 @@ function quant_taxonomy_term_update(EntityInterface $entity) {
 
   if (!$quant_enabled || !$quant_taxonomy_enabled) {
     return;
+  }
+
+  // If entity default revision is unpublished then unpublish in Quant.
+  if (!$entity->isPublished() && $entity->isDefaultRevision()) {
+    // Trigger an unpublish event.
+    Seed::unpublishTaxonomyTerm($entity);
   }
 
   $context = [
@@ -259,11 +265,17 @@ function _quant_entity_update_op(EntityInterface $entity) {
  * @todo Entity support.
  */
 function _quant_entity_delete_op(EntityInterface $entity) {
-  if ($entity->getEntityTypeId() != 'node') {
-    return;
+
+  switch ($entity->getEntityTypeId()) {
+    case 'node':
+      Seed::unpublishNode($entity);
+      break;
+
+    case 'taxonomy_term':
+      Seed::unpublishTaxonomyTerm($entity, $langcode);
+      break;
   }
 
-  Seed::unpublishNode($entity);
 }
 
 /**

--- a/quant.module
+++ b/quant.module
@@ -272,7 +272,7 @@ function _quant_entity_delete_op(EntityInterface $entity) {
       break;
 
     case 'taxonomy_term':
-      Seed::unpublishTaxonomyTerm($entity, $langcode);
+      Seed::unpublishTaxonomyTerm($entity);
       break;
   }
 

--- a/src/Seed.php
+++ b/src/Seed.php
@@ -90,7 +90,8 @@ class Seed {
     $statusCode = $redirect->getStatusCode();
 
     if (!(bool) $statusCode && !$redirect->isNew()) {
-      \Drupal::service('event_dispatcher')->dispatch(new QuantEvent('', $source, [], NULL), QuantEvent::UNPUBLISH); return;
+      \Drupal::service('event_dispatcher')->dispatch(new QuantEvent('', $source, [], NULL), QuantEvent::UNPUBLISH);
+      return;
     }
 
     \Drupal::service('event_dispatcher')->dispatch(new QuantRedirectEvent($source, $destination, $statusCode), QuantRedirectEvent::UPDATE);


### PR DESCRIPTION
See issue https://github.com/quantcdn/drupal/issues/135

Canonical redirect and term page are unpublished when term is unpublished. The additional redirect wasn't unpublished in Quant. Should we unpublish since the page is unpublished?

<img width="1133" alt="Screen Shot 2023-02-09 at 10 01 37 PM" src="https://user-images.githubusercontent.com/282024/218016447-6ec16014-d524-4881-912b-80964deaef35.png">

<img width="1143" alt="Screen Shot 2023-02-09 at 10 02 01 PM" src="https://user-images.githubusercontent.com/282024/218016478-f45e414e-b9c6-414f-8e33-e1d53dce2c56.png">

Canonical redirect, additional redirect, and term page are unpublished when term is deleted.

<img width="1155" alt="Screen Shot 2023-02-09 at 10 21 23 PM" src="https://user-images.githubusercontent.com/282024/218018285-cb0cffcc-2028-4dc8-b4f6-2c7c29c633a4.png">

<img width="1172" alt="Screen Shot 2023-02-09 at 10 21 34 PM" src="https://user-images.githubusercontent.com/282024/218018290-bbafb4e2-a4c0-4230-a637-b144973be22c.png">
