### PR TITLE
Added support for files (with wildcard).

### DIFF
--- a/modules/quant_cron/quant_cron.module
+++ b/modules/quant_cron/quant_cron.module
@@ -227,7 +227,7 @@ function quant_cron_get_files_from_paths($files_textarea) {
   }
 
   foreach ($paths as $path) {
-    foreach (glob($path) as $filename) {
+    foreach (glob(trim($path)) as $filename) {
       if (is_file($filename)) {
         $path = str_replace(DRUPAL_ROOT, '', $filename);
         $files[] = $path;

--- a/modules/quant_cron/quant_cron.module
+++ b/modules/quant_cron/quant_cron.module
@@ -8,6 +8,7 @@
 use Drupal\quant\Seed;
 use Drupal\Core\Form\FormState;
 use Drupal\quant\Plugin\QueueItem\RouteItem;
+use Drupal\quant\Plugin\QueueItem\FileItem;
 use Drupal\node\Entity\Node;
 use Drupal\user\Entity\User;
 use Drupal\views\Views;
@@ -39,6 +40,7 @@ function quant_cron_cron() {
   ];
 
   $routes = [];
+  $files = [];
 
   // Add nodes.
   if ($form_state->getValue('entity_node')) {
@@ -93,12 +95,17 @@ function quant_cron_cron() {
 
   // Add file routes.
   if ($form_state->getValue('robots')) {
-    $routes[] = '/robots.txt';
+    $files[] = '/robots.txt';
   }
 
   // Add theme file routes.
   if ($form_state->getValue('theme_assets')) {
-    $routes = array_merge($routes, quant_cron_get_theme_routes());
+    $files = array_merge($files, quant_cron_get_theme_routes());
+  }
+
+  // Add local files.
+  if ($form_state->getValue('file_paths')) {
+    $files = array_merge($files, quant_cron_get_files_from_paths($form_state->getValue('file_paths_textarea')));
   }
 
   // Add views routes.
@@ -109,6 +116,13 @@ function quant_cron_cron() {
   // Add taxonomy term routes.
   if ($form_state->getValue('entity_taxonomy_term')) {
     $routes = array_merge($routes, quant_cron_get_taxonomy_routes());
+  }
+
+  // Send files.
+  foreach ($files as $file) {
+    \Drupal::logger('quant_cron')->notice("quant_cron sending file: @route", ['@route' => $file]);
+    $file_item = new FileItem(['file' => $file]);
+    $file_item->send();
   }
 
   // Send any added routes.
@@ -198,6 +212,30 @@ function quant_cron_get_theme_routes() {
   }
 
   return $paths;
+}
+
+/**
+ * Helper: Get custom file paths.
+ */
+function quant_cron_get_files_from_paths($files_textarea) {
+  $paths = [];
+  $files = [];
+
+  foreach (explode(PHP_EOL, $files_textarea) as $path) {
+    // Paths must be relative to the drupal web root.
+    $paths[] = DRUPAL_ROOT . "/" . ltrim($path, '/');
+  }
+
+  foreach ($paths as $path) {
+    foreach (glob($path) as $filename) {
+      if (is_file($filename)) {
+        $path = str_replace(DRUPAL_ROOT, '', $filename);
+        $files[] = $path;
+      }
+    }
+  }
+
+  return $files;
 }
 
 /**

--- a/modules/quant_cron/src/Form/CronSettingsForm.php
+++ b/modules/quant_cron/src/Form/CronSettingsForm.php
@@ -146,6 +146,25 @@ class CronSettingsForm extends FormBase {
       '#default_value' => $config->get('routes_export'),
     ];
 
+    $form['file_paths'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('File paths'),
+      '#description' => $this->t('Exports files with support for wildcards.'),
+      '#default_value' => $config->get('file_paths'),
+    ];
+
+    $form['file_paths_textarea'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Local files'),
+      '#description' => $this->t('Add paths to local files on disk. Must be relative to the Drupal webroot. Wildcards are accepted.'),
+      '#states' => [
+        'visible' => [
+          ':input[name="file_paths"]' => ['checked' => TRUE],
+        ],
+      ],
+      '#default_value' => $config->get('file_paths_textarea'),
+    ];
+
     $form['robots'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Robots.txt'),
@@ -187,6 +206,8 @@ class CronSettingsForm extends FormBase {
     $config = $this->configFactory->getEditable('quant_cron.settings');
     $config->set('routes', $form_state->getValue('routes'))->save();
     $config->set('routes_export', $form_state->getValue('routes_textarea'))->save();
+    $config->set('file_paths', $form_state->getValue('file_paths'))->save();
+    $config->set('file_paths_textarea', $form_state->getValue('file_paths_textarea'))->save();
     $config->set('entity_node', $form_state->getValue('entity_node'))->save();
     $config->set('entity_node_languages', $form_state->getValue('entity_node_languages'))->save();
     $config->set('entity_node_bundles', $form_state->getValue('entity_node_bundles'))->save();

--- a/modules/quant_search/src/Form/QuantSearchPageForm.php
+++ b/modules/quant_search/src/Form/QuantSearchPageForm.php
@@ -363,7 +363,7 @@ class QuantSearchPageForm extends EntityForm {
         '#options' => $language_codes,
         '#default_value' => $facet['facet_language'] ?? 'en',
       ];
-      
+
       $form['facets'][$i]['facet_limit'] = [
         '#type' => 'number',
         '#title' => $this->t('Facet limit'),

--- a/src/Commands/QuantDrushCommands.php
+++ b/src/Commands/QuantDrushCommands.php
@@ -148,6 +148,8 @@ class QuantDrushCommands extends DrushCommands {
       'redirects',
       'routes',
       'routes_textarea',
+      'file_paths',
+      'file_paths_textarea',
       'robots',
       'lunr',
     ];

--- a/src/EventSubscriber/CollectionSubscriber.php
+++ b/src/EventSubscriber/CollectionSubscriber.php
@@ -138,7 +138,7 @@ class CollectionSubscriber implements EventSubscriberInterface {
    */
   private function collectFilesOnDisk($paths, $event) {
     foreach ($paths as $path) {
-      foreach (glob($path) as $filename) {
+      foreach (glob(trim($path)) as $filename) {
         if (is_file($filename)) {
           $path = str_replace(DRUPAL_ROOT, '', $filename);
           $event->queueItem(['file' => $path]);

--- a/src/EventSubscriber/CollectionSubscriber.php
+++ b/src/EventSubscriber/CollectionSubscriber.php
@@ -134,12 +134,23 @@ class CollectionSubscriber implements EventSubscriberInterface {
   }
 
   /**
-   * Collect files for quant seeding.
+   * Collect files based on provided paths on disk.
    */
-  public function collectFiles(CollectFilesEvent $event) {
-    if (!$event->getFormState()->getValue('theme_assets')) {
-      return;
+  private function collectFilesOnDisk($paths, $event) {
+    foreach ($paths as $path) {
+      foreach (glob($path) as $filename) {
+        if (is_file($filename)) {
+          $path = str_replace(DRUPAL_ROOT, '', $filename);
+          $event->queueItem(['file' => $path]);
+        }
+      }
     }
+  }
+
+  /**
+   * Collect files based on provided paths on disk.
+   */
+  private function collectThemeFiles($event) {
 
     // @todo Support multiple themes (e.g site may have multiple themes changing by route).
     $config = $this->configFactory->get('system.theme');
@@ -186,6 +197,27 @@ class CollectionSubscriber implements EventSubscriberInterface {
       $path = str_replace(DRUPAL_ROOT, '', $fileInfo->getPathname());
       $event->queueItem(['file' => $path]);
     }
+
+  }
+
+  /**
+   * Collect files for quant seeding.
+   */
+  public function collectFiles(CollectFilesEvent $event) {
+
+    if ($event->getFormState()->getValue('file_paths')) {
+      $paths = [];
+      foreach (explode(PHP_EOL, $event->getFormState()->getValue('file_paths_textarea')) as $path) {
+        // Paths must be relative to the drupal web root.
+        $paths[] = DRUPAL_ROOT . "/" . ltrim($path, '/');
+      }
+      $this->collectFilesOnDisk($paths, $event);
+    }
+
+    if ($event->getFormState()->getValue('theme_assets')) {
+      $this->collectThemeFiles($event);
+    }
+
   }
 
   /**

--- a/src/Form/SeedForm.php
+++ b/src/Form/SeedForm.php
@@ -220,7 +220,7 @@ class SeedForm extends FormBase {
     $form['routes'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Custom routes'),
-      '#description' => $this->t('Exports custom list of routes.  May be content or files.'),
+      '#description' => $this->t('Exports custom list of individual routes.  May be content or files.'),
       '#default_value' => $seed_config->get('routes'),
     ];
 
@@ -234,6 +234,25 @@ class SeedForm extends FormBase {
         ],
       ],
       '#default_value' => $seed_config->get('routes_textarea'),
+    ];
+
+    $form['file_paths'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('File paths'),
+      '#description' => $this->t('Exports files with support for wildcards.'),
+      '#default_value' => $seed_config->get('file_paths'),
+    ];
+
+    $form['file_paths_textarea'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Local files'),
+      '#description' => $this->t('Add paths to local files on disk. Must be relative to the Drupal webroot. Wildcards are accepted.'),
+      '#states' => [
+        'visible' => [
+          ':input[name="file_paths"]' => ['checked' => TRUE],
+        ],
+      ],
+      '#default_value' => $seed_config->get('file_paths_textarea'),
     ];
 
     $form['robots'] = [
@@ -308,6 +327,8 @@ class SeedForm extends FormBase {
       ->set('redirects', $form_state->getValue('redirects'))
       ->set('routes', $form_state->getValue('routes'))
       ->set('routes_textarea', $form_state->getValue('routes_textarea'))
+      ->set('file_paths', $form_state->getValue('file_paths'))
+      ->set('file_paths_textarea', $form_state->getValue('file_paths_textarea'))
       ->set('robots', $form_state->getValue('robots'))
       ->set('lunr', $form_state->getValue('lunr'))
       ->save();


### PR DESCRIPTION

![wildcard-files](https://user-images.githubusercontent.com/1256274/218925166-7a521a0c-c0d1-4d8b-ac23-1796c83e8291.jpg)

Allows for relative `/path/to/files/*.ext` for more flexible support over adding files in bulk that may not be picked up ordinarily by the seeding process.

Added to both regular seed & cron.