### PR TITLE
Add Xpath Follow Links functionality (D7)

### DIFF
--- a/quant.admin.inc
+++ b/quant.admin.inc
@@ -64,7 +64,7 @@ function quant_config() {
   $form['follow_links_fieldset']['quant_xpath_selectors'] = [
     '#type' => 'textarea',
     '#title' => t('Links to follow'),
-    '#default_value' => variable_get('quant_xpath_selectors', '//a[contains(@href,"page=") and contains(text(), "next")]\r\n//a[starts-with(@href, "/") and contains(text(), "first")]'),
+    '#default_value' => variable_get('quant_xpath_selectors', "//a[contains(@href,\"page=\") and contains(text(), \"next\")]\r\n//a[starts-with(@href, \"/\") and contains(text(), \"first\")]"),
     '#description' => t('Provide one xpath per line for anchor links to queue when detected.'),
   ];
 

--- a/quant.admin.inc
+++ b/quant.admin.inc
@@ -47,6 +47,27 @@ function quant_config() {
     '#default_value' => variable_get('quant_enabled_views', TRUE),
   ];
 
+  $form['follow_links_fieldset'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Follow links'),
+    '#description' => t('Automatically add certain links to the queue (e.g Views pagination)'),
+    '#attached' => array(
+      'library' => array(
+        array('system', 'drupal.collapse'),
+      ),
+    ),
+    '#attributes' => array(
+      'class' => array('collapsible', 'collapsed')
+    ),
+  ];
+
+  $form['follow_links_fieldset']['quant_xpath_selectors'] = [
+    '#type' => 'textarea',
+    '#title' => t('Links to follow'),
+    '#default_value' => variable_get('quant_xpath_selectors', '//a[contains(@href,"page=") and contains(text(), "next")]\r\n//a[starts-with(@href, "/") and contains(text(), "first")]'),
+    '#description' => t('Provide one xpath per line for anchor links to queue when detected.'),
+  ];
+
   $form['disable_content_drafts'] = array(
     '#type' => 'checkbox',
     '#title' => t('Disable content drafts'),
@@ -217,27 +238,6 @@ function quant_seed_settings() {
       ],
     ],
     '#default_value' => variable_get('quant_custom_routes', FALSE),
-  ];
-
-  $form['follow_links_fieldset'] = [
-    '#type' => 'fieldset',
-    '#title' => t('Follow links'),
-    '#description' => t('Automatically add certain links to the queue (e.g Views pagination)'),
-    '#attached' => array(
-      'library' => array(
-        array('system', 'drupal.collapse'),
-      ),
-    ),
-    '#attributes' => array(
-      'class' => array('collapsible')
-    ),
-  ];
-
-  $form['follow_links_fieldset']['quant_xpath_selectors'] = [
-    '#type' => 'checkbox',
-    '#title' => t('Links to follow'),
-    '#default_value' => variable_get('quant_xpath_selectors', '//a[contains(@href,"page=") and contains(text(), "next")]\r\n//a[starts-with(@href, "/") and contains(text(), "first")]'),
-    '#description' => t('Provide one xpath per line for anchor links to queue when detected.'),
   ];
 
   $form['quant_robots'] = [

--- a/quant.admin.inc
+++ b/quant.admin.inc
@@ -219,6 +219,27 @@ function quant_seed_settings() {
     '#default_value' => variable_get('quant_custom_routes', FALSE),
   ];
 
+  $form['follow_links_fieldset'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Follow links'),
+    '#description' => t('Automatically add certain links to the queue (e.g Views pagination)'),
+    '#attached' => array(
+      'library' => array(
+        array('system', 'drupal.collapse'),
+      ),
+    ),
+    '#attributes' => array(
+      'class' => array('collapsible')
+    ),
+  ];
+
+  $form['follow_links_fieldset']['quant_xpath_selectors'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Links to follow'),
+    '#default_value' => variable_get('quant_xpath_selectors', '//a[contains(@href,"page=") and contains(text(), "next")]\r\n//a[starts-with(@href, "/") and contains(text(), "first")]'),
+    '#description' => t('Provide one xpath per line for anchor links to queue when detected.'),
+  ];
+
   $form['quant_robots'] = [
     '#type' => 'checkbox',
     '#title' => t('Export robots.txt'),

--- a/quant.install
+++ b/quant.install
@@ -24,3 +24,14 @@ function quant_update_7000() {
   variable_set('quant_token_secret', bin2hex(random_bytes(32)));
   variable_set('quant_token_timeout', '+1 minute');
 }
+
+
+/**
+ * Migrate to new default XPath selectors variable.
+ */
+function quant_update_7001() {
+  if (variable_get('quant_pager_xpath')) {
+    variable_set('quant_xpath_selectors', variable_get('quant_pager_xpath'));
+    variable_del('quant_pager_xpath');
+  }
+}

--- a/quant.module
+++ b/quant.module
@@ -527,7 +527,10 @@ function quant_seed($url, array $context = array()) {
   $xpath_urls = isset($context['xpath_urls']) ? $context['xpath_urls'] : [];
 
   $xpath_selectors = array();
-  $links_config = variable_get('quant_xpath_selectors');
+  $links_config = variable_get(
+    'quant_xpath_selectors',
+    "//a[contains(@href,\"page=\") and contains(text(), \"next\")]\r\n//a[starts-with(@href, \"/\") and contains(text(), \"first\")]"
+  );
 
   foreach (explode(PHP_EOL, $links_config) as $links_line) {
     $xpath_selectors[] = trim($links_line);

--- a/quant.module
+++ b/quant.module
@@ -520,40 +520,39 @@ function quant_seed($url, array $context = array()) {
 
   $queue = quant_get_queue();
 
+  // Pagination support.
   $document = new \DOMDocument();
   @$document->loadHTML($markup);
   $xpath = new \DOMXPath($document);
-  $page_urls = isset($context['page_urls']) ? $context['page_urls'] : [];
+  $xpath_urls = isset($context['xpath_urls']) ? $context['xpath_urls'] : [];
 
-  $pager_xpath = array(
-    '//a[contains(@href,"page=") and contains(text(), "next")]',
-    '//a[starts-with(@href, "/") and contains(text(), "first")]',
-  );
+  $xpath_selectors = array();
+  $links_config = variable_get('quant_xpath_selectors');
 
-  if (variable_get('quant_pager_xpath')) {
-    $pager_xpath = explode(PHP_EOL, variable_get('quant_pager_xpath'));
+  foreach (explode(PHP_EOL, $links_config) as $links_line) {
+    $xpath_selectors[] = trim($links_line);
   }
 
-  foreach ($pager_xpath as $xpath_query) {
+  foreach ($xpath_selectors as $xpath_query) {
     foreach ($xpath->query($xpath_query) as $node) {
       $original_href = $new_href = $node->getAttribute('href');
       if ($original_href[0] === '?') {
         $new_href = strtok($path, '?') . $original_href;
       }
 
-      $pager_url = $base . $new_href;
+      $xpath_url = $base . $new_href;
 
-      if (in_array($pager_url, $page_urls)) {
+      if (in_array($xpath_url, $xpath_urls)) {
         continue;
       }
 
-      $page_urls[] = $pager_url;
+      $xpath_urls[] = $xpath_url;
       $next_context = array(
         'find_pager' => TRUE,
         'type' => 'view',
-        'page_urls' => $page_urls,
+        'xpath_urls' => $xpath_urls,
       );
-      $item = array('quant_seed', array($pager_url, $next_context));
+      $item = array('quant_seed', array($xpath_url, $next_context));
       $queue->createItem($item);
     }
   }


### PR DESCRIPTION
# Issue
The D7 version of the module does not feature Follow Links functionality as D8 does. This is quite a handy feature that allows pagination and other dynamic links capture.

# Proposed solution
Introduce Follow Links config and logic that works the same way as the D8 version.