### PR TITLE
[ISSUE-144] Add module configure links. Credit @Sahana_N on drupal.org.

### DIFF
--- a/modules/quant_api/quant_api.info.yml
+++ b/modules/quant_api/quant_api.info.yml
@@ -4,6 +4,6 @@ package: Quant
 
 type: module
 core_version_requirement: ^9.3 || ^10
-
+configure: quant_api.settings_form
 dependencies:
   - drupal:quant

--- a/modules/quant_cron/quant_cron.info.yml
+++ b/modules/quant_cron/quant_cron.info.yml
@@ -4,6 +4,6 @@ package: Quant
 
 type: module
 core_version_requirement: ^9.3 || ^10
-
+configure: quant_cron.settings_form
 dependencies:
   - quant:quant_api

--- a/modules/quant_search/quant_search.info.yml
+++ b/modules/quant_search/quant_search.info.yml
@@ -4,7 +4,7 @@ package: Quant
 
 type: module
 core_version_requirement: ^9.3 || ^10
-
+configure: quant_search.main
 dependencies:
   - drupal:quant
   - drupal:quant_api

--- a/quant.info.yml
+++ b/quant.info.yml
@@ -4,6 +4,6 @@ package: Quant
 
 type: module
 core_version_requirement: ^9.3 || ^10
-
+configure: quant.config
 dependencies:
   - quant:quant_api


### PR DESCRIPTION
See d.o issue: https://www.drupal.org/project/quantcdn/issues/3342600

This adds the configure link to all modules with a Quant tab/page.

**Before**

<img width="1104" alt="Screen Shot 2023-03-02 at 12 09 02 PM" src="https://user-images.githubusercontent.com/282024/222543615-2813add1-ea23-4929-8fa3-1c556fcbb00f.png">

**After**

<img width="893" alt="Screen Shot 2023-03-02 at 12 18 27 PM" src="https://user-images.githubusercontent.com/282024/222543635-6d16a3b1-9079-4309-a091-d2ef03568b7e.png">
