### PR TITLE
[bugfix] Ensure node_load success with passed revision.

### DIFF
--- a/quant.module
+++ b/quant.module
@@ -185,8 +185,10 @@ function quant_node_menu_load($nid) {
     $node = node_load($nid, $revision);
     // Override the status. This prevents Drupal from adding the standard
     // unpublished classes to the node.
-    $node->status = 1;
-    return $node;
+    if (!empty($node)) {
+      $node->status = 1;
+      return $node;
+    }
   }
 
   return node_load($nid);


### PR DESCRIPTION
A customer has reported an issue not seen elsewhere when an invalid revision id is passed to `node_load`.

We will continue to investigate to see where invalid revision id is coming from, but for now this hardening step solves the issue and returns the currently published node. The same issue cannot be replicated elsewhere.