### PR TITLE
Resolve internal redirect failures when using storage_api.

### DIFF
--- a/modules/quant_api/quant_api.module
+++ b/modules/quant_api/quant_api.module
@@ -209,6 +209,12 @@ function quant_api_quant_seed($location, $data, $meta = [], $context = []) {
 
     if (isset($item['existing_md5']) && md5_file($loc) == $item['existing_md5']) {
       // This file hasn't changed since the last export.
+      // Remove any temporary files and continue.
+      if ($external_url || variable_get('quant_alternate_file_handler', FALSE)) {
+        if (strpos($loc, sys_get_temp_dir()) === 0) {
+          unlink($loc);
+        }
+      }
       continue;
     }
 

--- a/modules/quant_api/quant_api.module
+++ b/modules/quant_api/quant_api.module
@@ -226,7 +226,7 @@ function quant_api_quant_seed($location, $data, $meta = [], $context = []) {
 
     // Remove temporary files where alternate file handler is enabled
     // and the file path starts with the temporary directory.
-    if (variable_get('quant_alternate_file_handler', FALSE)) {
+    if ($external_url || variable_get('quant_alternate_file_handler', FALSE)) {
       if (strpos($loc, sys_get_temp_dir()) === 0) {
         unlink($loc);
       }

--- a/modules/quant_api/quant_api.module
+++ b/modules/quant_api/quant_api.module
@@ -153,6 +153,12 @@ function quant_api_quant_seed($location, $data, $meta = [], $context = []) {
     $file = urldecode($item['path']);
     $on_disk = parse_url($file, PHP_URL_PATH);
     $domain = parse_url($file, PHP_URL_HOST);
+    $external_url = FALSE;
+
+    // @todo: Support relative protocol assets.
+    if (substr($file, 0, 2) === "//") {
+      continue;
+    }
 
     if (!empty($domain) && stripos($base_url, $domain) == -1) {
       // @todo: Determine local vs. remote.
@@ -167,9 +173,31 @@ function quant_api_quant_seed($location, $data, $meta = [], $context = []) {
       $loc = str_replace('/system/files', $private_path, $file);
     }
 
-    // Support alternate file handling if enabled
-    if (variable_get('quant_alternate_file_handler', FALSE)) {
-      $loc = _retrieve_file($file);
+    // Support retrieval of assets in the allowed domains list.
+    // This will always use the alternate file handler (retrieve via HTTP).
+    $allowed_domains = [];
+    foreach (explode(PHP_EOL, variable_get('quant_allowed_external_domains', '')) as $domain) {
+      $allowed_domains[] = trim($domain);
+    }
+
+    $external_url = FALSE;
+    if (!empty($item['original_path']) && strpos($item['original_path'], "http") === 0) {
+      if (in_array(parse_url($item['original_path'], PHP_URL_HOST), $allowed_domains)) {
+        $external_url = TRUE;
+      }
+      else {
+        continue;
+      }
+    }
+
+    if ($external_url) {
+      $loc = _retrieve_file($item['original_path'], TRUE);
+    }
+    else {
+      // Support alternate file handling if enabled
+      if (variable_get('quant_alternate_file_handler', FALSE)) {
+        $loc = _retrieve_file($file);
+      }
     }
 
     if (!file_exists($loc)) {
@@ -193,6 +221,7 @@ function quant_api_quant_seed($location, $data, $meta = [], $context = []) {
     quant_seed_file($file, [
       'location' => $loc,
       'request' => $on_disk,
+      'external' => $external_url,
     ]);
 
     // Remove temporary files where alternate file handler is enabled
@@ -212,9 +241,6 @@ function quant_api_quant_seed($location, $data, $meta = [], $context = []) {
 function quant_api_quant_seed_file($url, $context) {
   global $base_url;
 
-  // Rebuild the file URL used for the local HEAD request.
-  $url = _rebuild_file_url($url);
-
   $api = variable_get('quant_api_endpoint', QUANT_API_ENDPOINT_DEFAULT) . '/v1';
 
   if (empty($api)) {
@@ -227,60 +253,65 @@ function quant_api_quant_seed_file($url, $context) {
     return;
   }
 
-  if (!file_exists($context['location'])) {
-    quant_log('Unable to upload %u, file does not exist', ['%u' => $context['location']]);
-    return;
-  }
+  // Skip file exists and is accessible checks for external files.
+  if(empty($context['external']) || $context['external'] !== TRUE) {
 
-  // Issue a HEAD request to the file path.
-  $options = array(
-    'max_redirects' => 0,
-    'headers' => array(
-      'Host' => variable_get('quant_hostname', parse_url($base_url, PHP_URL_HOST)),
-      'User-Agent' => 'Quant (+http://quantcdn.io)',
-    ),
-    'method' => 'HEAD',
-  );
+    // Rebuild the file URL used for the local HEAD request.
+    $url = _rebuild_file_url($url);
 
-  // Ensure url is absolute for internal HEAD request.
-  if(strpos($url, "http") !== 0) {
-    $base = variable_get('quant_base_url', $base_url);
-    // Clean up multiple slashes in the file path.
-    $url = preg_replace('~/+~', '/', $url);
-    // Ensure url path starts with a slash.
-    if (substr($url, 0, 1) !== '/') {
-      $url = '/' . $url;
+    if (!file_exists($context['location'])) {
+      quant_log('Unable to upload %u, file does not exist', ['%u' => $context['location']]);
+      return;
     }
-    $url = "{$base}{$url}";
-  }
 
-  if (!variable_get('quant_verify_ssl', TRUE)) {
-    $options['context'] = stream_context_create(array(
-      'ssl' => array(
-        'verify_peer' => FALSE,
-        'verify_peer_name' => FALSE,
-      )
-    ));
-  }
+    // Issue a HEAD request to the file path.
+    $options = array(
+      'max_redirects' => 0,
+      'headers' => array(
+        'Host' => variable_get('quant_hostname', parse_url($base_url, PHP_URL_HOST)),
+        'User-Agent' => 'Quant (+http://quantcdn.io)',
+      ),
+      'method' => 'HEAD',
+    );
 
-  $file_head = drupal_http_request($url, $options);
+    // Ensure url is absolute for internal HEAD request.
+    if(strpos($url, "http") !== 0) {
+      $base = variable_get('quant_base_url', $base_url);
+      // Ensure url path starts with a slash.
+      if (substr($url, 0, 1) !== '/') {
+        $url = '/' . $url;
+      }
+      $url = "{$base}{$url}";
+    }
 
-  // Disallow files that do not return 200 OK or redirect.
-  if ($file_head->code != 200 && $file_head->code != 302 && $file_head->code != 301) {
-    quant_log('Unable to seed file: %url. Unexpected response code: %code', array(
-      '%url' => $url,
-      '%code' => $file_head->code,
-    ), WATCHDOG_ERROR);
-    return;
-  }
+    if (!variable_get('quant_verify_ssl', TRUE)) {
+      $options['context'] = stream_context_create(array(
+        'ssl' => array(
+          'verify_peer' => FALSE,
+          'verify_peer_name' => FALSE,
+        )
+      ));
+    }
 
-  // Support file specific additional headers.
-  if ($file_head->code == 200) {
-    $custom_headers = array_intersect_key($file_head->headers, array_flip(array(
-      'content-disposition',
-      'content-transfer-encoding',
-      'content-type'
-    )));
+    $file_head = drupal_http_request($url, $options);
+
+    // Disallow files that do not return 200 OK or redirect.
+    if ($file_head->code != 200 && $file_head->code != 302 && $file_head->code != 301) {
+      quant_log('Unable to seed file: %url. Unexpected response code: %code', array(
+        '%url' => $url,
+        '%code' => $file_head->code,
+      ), WATCHDOG_ERROR);
+      return;
+    }
+
+    // Support file specific additional headers.
+    if ($file_head->code == 200) {
+      $custom_headers = array_intersect_key($file_head->headers, array_flip(array(
+        'content-disposition',
+        'content-transfer-encoding',
+        'content-type'
+      )));
+    }
   }
 
   $headers = quant_api_get_request_headers() + array(
@@ -418,6 +449,9 @@ function _rebuild_file_url($url) {
     $rebuilt_url .= "?" . $parsed_url['query'];
   }
 
+  // Clean up multiple slashes in the file path.
+  $rebuilt_url = preg_replace('~/+~', '/', $rebuilt_url);
+
   return $rebuilt_url;
 
 }
@@ -435,16 +469,23 @@ function _rebuild_file_url($url) {
  * @return string
  *   The absolute local path on disk to the temporary file.
  */
-function _retrieve_file($url, $redirected=FALSE) {
+function _retrieve_file($url, $external_url=FALSE, $redirected=FALSE) {
 
   $path = $url;
-  $url = _rebuild_file_url($url);
+  $host = variable_get('quant_hostname', parse_url($base_url, PHP_URL_HOST));
+
+  if ($external_url) {
+    $host = parse_url($url, PHP_URL_HOST);
+  }
+  else {
+    $url = _rebuild_file_url($url);
+  }
 
   // Issue a GET request to the file path.
   $options = array(
     'max_redirects' => 0,
     'headers' => array(
-      'Host' => variable_get('quant_hostname', parse_url($base_url, PHP_URL_HOST)),
+      'Host' => $host,
       'User-Agent' => 'Quant (+http://quantcdn.io)',
     ),
     'method' => 'GET',
@@ -453,8 +494,6 @@ function _retrieve_file($url, $redirected=FALSE) {
   // Ensure url is absolute for internal GET request.
   if(strpos($url, "http") !== 0) {
     $base = variable_get('quant_base_url', $base_url);
-    // Clean up multiple slashes in the file path.
-    $url = preg_replace('~/+~', '/', $url);
     // Ensure url path starts with a slash.
     if (substr($url, 0, 1) !== '/') {
       $url = '/' . $url;
@@ -486,7 +525,7 @@ function _retrieve_file($url, $redirected=FALSE) {
     // Note: The Drupal HTTP client will provide a redirect that is not always
     // correct here, as it will bypass internal/loopback addresses.
     // For this reason we intercept and rewrite it.
-    return (_retrieve_file($file_get->redirect_url, TRUE));
+    return (_retrieve_file($file_get->redirect_url, $skip_rebuild, TRUE));
   }
   else {
     quant_log('Unable to retrieve file via alt handler: %url. Unexpected response code: %code', array(

--- a/modules/quant_api/quant_api.module
+++ b/modules/quant_api/quant_api.module
@@ -207,6 +207,12 @@ function quant_api_quant_seed($location, $data, $meta = [], $context = []) {
       continue;
     }
 
+    // Safety net: Return if mime type is text/html.
+    // This is to prevent any content routes incorrectly being sent as files.
+    if (preg_match('/text\/html/', mime_content_type($loc))) {
+      continue;
+    }
+
     if (isset($item['existing_md5']) && md5_file($loc) == $item['existing_md5']) {
       // This file hasn't changed since the last export.
       // Remove any temporary files and continue.

--- a/modules/quant_api/quant_api.module
+++ b/modules/quant_api/quant_api.module
@@ -234,6 +234,7 @@ function quant_api_quant_seed_file($url, $context) {
 
   // Issue a HEAD request to the file path.
   $options = array(
+    'max_redirects' => 0,
     'headers' => array(
       'Host' => variable_get('quant_hostname', parse_url($base_url, PHP_URL_HOST)),
       'User-Agent' => 'Quant (+http://quantcdn.io)',
@@ -244,6 +245,8 @@ function quant_api_quant_seed_file($url, $context) {
   // Ensure url is absolute for internal HEAD request.
   if(strpos($url, "http") !== 0) {
     $base = variable_get('quant_base_url', $base_url);
+    // Clean up multiple slashes in the file path.
+    $url = preg_replace('~/+~', '/', $url);
     $url = "{$base}{$url}";
   }
 
@@ -258,8 +261,8 @@ function quant_api_quant_seed_file($url, $context) {
 
   $file_head = drupal_http_request($url, $options);
 
-  // Disallow files that do not return 200 OK.
-  if ($file_head->code != 200) {
+  // Disallow files that do not return 200 OK or redirect.
+  if ($file_head->code != 200 && $file_head->code != 302 && $file_head->code != 301) {
     quant_log('Unable to seed file: %url. Unexpected response code: %code', array(
       '%url' => $url,
       '%code' => $file_head->code,
@@ -268,11 +271,13 @@ function quant_api_quant_seed_file($url, $context) {
   }
 
   // Support file specific additional headers.
-  $custom_headers = array_intersect_key($file_head->headers, array_flip(array(
-    'content-disposition',
-    'content-transfer-encoding',
-    'content-type'
-  )));
+  if ($file_head->code == 200) {
+    $custom_headers = array_intersect_key($file_head->headers, array_flip(array(
+      'content-disposition',
+      'content-transfer-encoding',
+      'content-type'
+    )));
+  }
 
   $headers = quant_api_get_request_headers() + array(
     'Quant-File-Url' => $context['request'],
@@ -389,7 +394,7 @@ function quant_api_unpublish_route($url) {
 function _rebuild_file_url($url) {
 
   // Parse the URL to capture query parameters (if any).
-  $parsed_url = parse_url($url);
+  $parsed_url = parse_url(urldecode($url));
 
   // Return the raw string if we cannot parse the URL.
   if (empty($parsed_url['path'])) {
@@ -426,12 +431,14 @@ function _rebuild_file_url($url) {
  * @return string
  *   The absolute local path on disk to the temporary file.
  */
-function _retrieve_file($url) {
+function _retrieve_file($url, $redirected=FALSE) {
 
   $path = $url;
+  $url = _rebuild_file_url($url);
 
   // Issue a GET request to the file path.
   $options = array(
+    'max_redirects' => 0,
     'headers' => array(
       'Host' => variable_get('quant_hostname', parse_url($base_url, PHP_URL_HOST)),
       'User-Agent' => 'Quant (+http://quantcdn.io)',
@@ -442,6 +449,8 @@ function _retrieve_file($url) {
   // Ensure url is absolute for internal GET request.
   if(strpos($url, "http") !== 0) {
     $base = variable_get('quant_base_url', $base_url);
+    // Clean up multiple slashes in the file path.
+    $url = preg_replace('~/+~', '/', $url);
     $url = "{$base}{$url}";
   }
 
@@ -456,11 +465,29 @@ function _retrieve_file($url) {
 
   // Retrieve the file, store in a temporary location, and use for file upload.
   $file_get = drupal_http_request($url, $options);
-  $tmp_filename = tempnam(sys_get_temp_dir(), basename($path));
-  $tmp_file = fopen($tmp_filename, "w+");
-  fwrite($tmp_file, $file_get->data);
-  fclose($tmp_file);
 
-  return $tmp_filename;
+  if ($file_get->code == 200) {
+    $rnd = drupal_random_key();
+    $tmp_filename = sys_get_temp_dir() . '/' . $rnd . urldecode(basename($path));
+    $tmp_file = fopen($tmp_filename, "w+");
+    fwrite($tmp_file, $file_get->data);
+    fclose($tmp_file);
+    return $tmp_filename;
+  }
+  elseif (!$redirected && $file_get->code == 301 || $file_get->code == 302) {
+    // Note: The Drupal HTTP client will provide a redirect that is not always
+    // correct here, as it will bypass internal/loopback addresses.
+    // For this reason we intercept and rewrite it.
+    return (_retrieve_file($file_get->redirect_url, TRUE));
+  }
+  else {
+    quant_log('Unable to retrieve file via alt handler: %url. Unexpected response code: %code', array(
+      '%url' => $url,
+      '%code' => $file_get->code,
+    ), WATCHDOG_ERROR);
+    return;
+  }
+
+  return null;
 
 }

--- a/modules/quant_api/quant_api.module
+++ b/modules/quant_api/quant_api.module
@@ -247,6 +247,10 @@ function quant_api_quant_seed_file($url, $context) {
     $base = variable_get('quant_base_url', $base_url);
     // Clean up multiple slashes in the file path.
     $url = preg_replace('~/+~', '/', $url);
+    // Ensure url path starts with a slash.
+    if (substr($url, 0, 1) !== '/') {
+      $url = '/' . $url;
+    }
     $url = "{$base}{$url}";
   }
 
@@ -451,6 +455,10 @@ function _retrieve_file($url, $redirected=FALSE) {
     $base = variable_get('quant_base_url', $base_url);
     // Clean up multiple slashes in the file path.
     $url = preg_replace('~/+~', '/', $url);
+    // Ensure url path starts with a slash.
+    if (substr($url, 0, 1) !== '/') {
+      $url = '/' . $url;
+    }
     $url = "{$base}{$url}";
   }
 

--- a/quant.admin.inc
+++ b/quant.admin.inc
@@ -221,8 +221,27 @@ function quant_seed_settings() {
 
   $form['quant_seed_theme_assets'] = array(
     '#type' => 'checkbox',
-    '#title' => t('Export theme assets'),
+    '#title' => t('Export default theme assets'),
     '#default_value' => variable_get('quant_seed_theme_assets', FALSE),
+  );
+
+  $form['quant_seed_additional_theme_assets_enabled'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Additional theme assets'),
+    '#description' => t('Exports CSS/JS/static assets from non-default themes.'),
+    '#default_value' => variable_get('quant_seed_additional_theme_assets_enabled', FALSE),
+  ];
+
+  $form['quant_seed_additional_theme_assets'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Export additional theme assets'),
+    '#default_value' => variable_get('quant_seed_additional_theme_assets', ''),
+    '#description' => t('Provide additional theme machine names (separated by newline)'),
+    '#states' => [
+      'visible' => [
+        ':input[name="quant_seed_additional_theme_assets_enabled"]' => ['checked' => TRUE],
+      ],
+    ],
   );
 
   if (module_exists('views')) {

--- a/quant.admin.inc
+++ b/quant.admin.inc
@@ -213,6 +213,34 @@ function quant_seed_settings() {
     ),
   );
 
+  $form['quant_seed_menu_paths_enabled'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Menu paths'),
+    '#description' => t('Exports routes as defined in a menu structure.'),
+    '#default_value' => variable_get('quant_seed_menu_paths_enabled', FALSE),
+  ];
+
+  // Filter by menu.
+  $menus = menu_get_menus();
+
+  $options = array();
+  foreach ($menus as $menu_name => $menu) {
+    $options[$menu_name] = $menu;
+  }
+
+  $form['quant_seed_menu_paths_bundles'] = array(
+    '#type' => 'checkboxes',
+    '#title' => t('Enabled menus for paths'),
+    '#description' => t('Optionally, restrict to these menus.'),
+    '#default_value' => variable_get('quant_seed_menu_paths_bundles', []),
+    '#options' => $options,
+    '#states' => array(
+      'visible' => array(
+        ':input[name="quant_seed_menu_paths_enabled"]' => array('checked' => TRUE),
+      ),
+    ),
+  );
+
   $form['quant_seed_entity_taxonomy'] = array(
     '#type' => 'checkbox',
     '#title' => t('Export taxonomy terms'),

--- a/quant.admin.inc
+++ b/quant.admin.inc
@@ -126,6 +126,13 @@ function quant_config() {
     '#default_value' => variable_get('quant_hostname', 'www.example.com'),
   );
 
+  $form['quant_allowed_external_domains'] = [
+    '#type' => 'textarea',
+    '#title' => t('Allowed external domains'),
+    '#description' => t('Optionally provide external domains embedded static assets should be retrieved from.'),
+    '#default_value' => variable_get('quant_allowed_external_domains', FALSE),
+  ];
+
   $form['#validate'][] = 'quant_form_quant_config_validate';
 
   return system_settings_form($form);
@@ -223,6 +230,14 @@ function quant_seed_settings() {
       '#type' => 'checkbox',
       '#title' => t('Export Views'),
       '#default_value' => variable_get('quant_seed_views', FALSE),
+    );
+  }
+
+  if (module_exists('page_manager')) {
+    $form['quant_seed_page_manager'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Export page manager pages'),
+      '#default_value' => variable_get('quant_seed_page_manager', FALSE),
     );
   }
 

--- a/quant.module
+++ b/quant.module
@@ -1305,6 +1305,7 @@ function quant_token_validate($route, $strict = TRUE) {
 function _rewrite_relative($markup) {
   global $base_url;
   $base = variable_get('quant_hostname', $base_url);
+  $base = preg_quote($base, '/');
   return preg_replace("/(https?:\/\/)?{$base}/i", '', $markup);
 }
 
@@ -1314,6 +1315,7 @@ function _rewrite_relative($markup) {
 function _is_url_internal($url) {
   global $base_url;
   $base = variable_get('quant_hostname', $base_url);
+  $base = preg_quote($base, '/');
   if (preg_match("/(https?:\/\/)?{$base}/i", $url)) {
     return TRUE;
   }

--- a/quant.module
+++ b/quant.module
@@ -813,9 +813,22 @@ function _quant_queue_taxonomy() {
 
 /**
  * Prepare the images to seed via batch.
+ *
+ * @param string $theme_machine_name
+ *   Optional theme machine name to seed assets for.
  */
-function _quant_queue_theme_assets() {
-  $theme_dir = drupal_get_path('theme', variable_get('theme_default', NULL));
+function _quant_queue_theme_assets($theme_machine_name = NULL) {
+
+  if (empty($theme_machine_name)) {
+    $theme_machine_name = variable_get('theme_default', NULL);
+  }
+
+  $theme_dir = drupal_get_path('theme', $theme_machine_name);
+
+  if (empty($theme_dir)) {
+    return;
+  }
+
   $files = file_scan_directory(DRUPAL_ROOT . "/$theme_dir", QUANT_THEME_FILE_MASK);
   ksort($files);
 
@@ -1025,6 +1038,12 @@ function _quant_seed_prepare(array $form = array(), array $form_state = array())
 
   if (variable_get('quant_seed_theme_assets')) {
     _quant_queue_theme_assets();
+  }
+
+  if (variable_get('quant_seed_additional_theme_assets')) {
+    foreach (explode(PHP_EOL, variable_get('quant_seed_additional_theme_assets')) as $theme) {
+      _quant_queue_theme_assets(trim($theme));
+    }
   }
 
   if (variable_get('quant_seed_views')) {
@@ -1306,7 +1325,7 @@ function _rewrite_relative($markup) {
   global $base_url;
   $base = variable_get('quant_hostname', $base_url);
   $base = preg_quote($base, '/');
-  return preg_replace("/(https?:\/\/)?{$base}/i", '', $markup);
+  return preg_replace("/(https?:\/\/){$base}/i", '', $markup);
 }
 
 /**

--- a/quant.module
+++ b/quant.module
@@ -748,6 +748,49 @@ function _quant_prepare_entity($type, $entity_id) {
 }
 
 /**
+ * Prepare a batch process for menu items.
+ *
+ * @param array $menus
+ *   Optionally filter by menu names.
+ */
+function _quant_queue_menu_paths(array $menus_filter = array()) {
+  global $base_url;
+  $base = variable_get('quant_base_url', $base_url);
+  $menus = menu_get_menus();
+
+  $options = array();
+  foreach ($menus as $menu_name => $menu) {
+
+    // Skip if not in a provided menu filter.
+    if (!empty($menus_filter) && !in_array($menu_name, $menus_filter)) {
+      continue;
+    }
+
+    $items = menu_load_links($menu_name);
+    $queue = quant_get_queue();
+
+    foreach ($items as $item) {
+      $alias = drupal_get_path_alias($item['link_path']);
+
+      // Exclude special routes (like '<front>')
+      if (strpos((trim($alias)), '<') === 0) {
+        continue;
+      }
+      $url =  $base . base_path() . $alias;
+
+      $item = array(
+        'quant_seed',
+        array(trim($url)),
+      );
+      $queue->createItem($item);
+
+    }
+
+  }
+
+}
+
+/**
  * Prepare a batch process for the node entity type.
  *
  * @param array $bundles
@@ -1038,6 +1081,11 @@ function _quant_seed_prepare(array $form = array(), array $form_state = array())
 
   if (variable_get('quant_seed_theme_assets')) {
     _quant_queue_theme_assets();
+  }
+
+  if (variable_get('quant_seed_menu_paths_bundles')) {
+    $menus = array_filter(variable_get('quant_seed_menu_paths_bundles'));
+    _quant_queue_menu_paths($menus);
   }
 
   if (variable_get('quant_seed_additional_theme_assets')) {

--- a/quant.module
+++ b/quant.module
@@ -852,6 +852,31 @@ function _quant_queue_theme_assets() {
 }
 
 /**
+ * Get a list of page manager paths.
+ */
+function _quant_queue_page_manager() {
+  global $base_url;
+  $base = variable_get('quant_base_url', $base_url);
+  $queue = quant_get_queue();
+
+  $config = array();
+  $pages = db_query('SELECT p.path FROM {page_manager_pages} p')->fetchAll();
+
+  foreach ($pages as $page) {
+    $url = "$base/" . $page->path;
+
+    $config['find_pager'] = TRUE;
+    $config['type'] = 'page_manager';
+
+    $item = array(
+      'quant_seed',
+      array(trim($url), $config),
+    );
+    $queue->createItem($item);
+  }
+}
+
+/**
  * Get a list of views paths.
  */
 function _quant_queue_views() {
@@ -1004,6 +1029,10 @@ function _quant_seed_prepare(array $form = array(), array $form_state = array())
 
   if (variable_get('quant_seed_views')) {
     _quant_queue_views();
+  }
+
+  if (variable_get('quant_seed_page_manager')) {
+    _quant_queue_page_manager();
   }
 
   if (variable_get('site_404', FALSE)) {

--- a/quant.module
+++ b/quant.module
@@ -607,6 +607,9 @@ function quant_seed($url, array $context = array()) {
  * Prepare a file export.
  */
 function quant_seed_file($url, $context = array()) {
+
+  quant_log('Sending file: !url', array('!url' => urldecode($url)));
+
   // @TODO: Files need different meta?
   $meta = array();
   drupal_alter('quant_file_meta', $meta, $context);


### PR DESCRIPTION
More cleanly handles redirects issued via `drupal_http_request` to use internal loopback & host header as configured in Quant.

This PR ended up having a lot of other things added as we were onboarding new users. See d.o issues:

- https://www.drupal.org/project/quantcdn/issues/3366905
- https://www.drupal.org/project/quantcdn/issues/3367160
- https://www.drupal.org/project/quantcdn/issues/3367163
- https://www.drupal.org/project/quantcdn/issues/3367162
- https://www.drupal.org/project/quantcdn/issues/3367161
- https://www.drupal.org/project/quantcdn/issues/3367167
- https://www.drupal.org/project/quantcdn/issues/3367165
