### PR TITLE
Hardcode the CI mariadb version to get around failure.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     services:
       mariadb:
-        image: mariadb
+        image: mariadb:10.11
         ports:
           - 3306
         env:


### PR DESCRIPTION
See d.o issue: https://www.drupal.org/project/quantcdn/issues/3366600