### PR TITLE
Update D7 seed trigger batch to work like D9+ version.

### DIFF
--- a/quant.admin.inc
+++ b/quant.admin.inc
@@ -276,23 +276,33 @@ function quant_seed_settings() {
   $form['trigger_quant_seed'] = array(
     '#type' => 'checkbox',
     '#title' => t('Trigger the batch'),
-    '#description' => t('<strong>Note:</strong> This will attempt to trigger the seed from the UI, depending on the size of your site and PHP configuration this may not work.'),
+    '#description' => t('<strong>Note:</strong> This will attempt to trigger the seed from the UI. Depending on the size of your site and your PHP configuration, this may not work. To try it, enable the option and click the <code>Save and Queue</code> button.'),
     '#weight' => 998,
   );
 
   $form = system_settings_form($form);
 
+  $form['actions']['submit']['#value'] = 'Save';
   $form['actions']['#weight'] = 998;
-  $form['#submit'][] = '_quant_queue_batch';
+  $form['actions']['submit']['#validate'][] = 'quant_form_quant_seed_validate';
 
   $form['save_and_queue'] = array(
     '#type' => 'submit',
     '#value' => 'Save and Queue',
-    '#submit' => array('system_settings_form_submit', '_quant_seed_prepare'),
+    '#submit' => array('system_settings_form_submit', '_quant_queue_batch'),
     '#weight' => 999,
   );
 
   return $form;
+}
+
+/**
+ * Validate the seed form to ensure that the settings are valid.
+ */
+function quant_form_quant_seed_validate($form = array(), &$form_state = array()) {
+  if (!empty($form_state['values']['trigger_quant_seed'])) {
+    drupal_set_message(t('To trigger the batch in the UI, check the option and click <code>Save and Queue</code>.'), "warning");
+  }
 }
 
 /**

--- a/quant.admin.inc
+++ b/quant.admin.inc
@@ -277,6 +277,7 @@ function quant_seed_settings() {
     '#type' => 'checkbox',
     '#title' => t('Trigger the batch'),
     '#description' => t('<strong>Note:</strong> This will attempt to trigger the seed from the UI. Depending on the size of your site and your PHP configuration, this may not work. To try it, enable the option and click the <code>Save and Queue</code> button.'),
+    '#default_value' => FALSE,
     '#weight' => 998,
   );
 

--- a/quant.module
+++ b/quant.module
@@ -1029,11 +1029,13 @@ function _quant_seed_prepare(array $form = array(), array $form_state = array())
  * Process the queue inline with a Drupal batch process.
  */
 function _quant_queue_batch() {
+  // Always prepare the queue.
+  _quant_seed_prepare();
+
+  // If it should be triggered via UI, create a batch process.
   if (!variable_get('trigger_quant_seed')) {
     return;
   }
-
-  _quant_seed_prepare();
 
   $batch = array(
     'title' => t('Quant seeding'),


### PR DESCRIPTION
This was a recent issue during user onboarding as there was some confusion around which button to click and it was different than D9+.

See d.o issue: https://www.drupal.org/project/quantcdn/issues/3366846

---
<img width="684" alt="Screen Shot 2023-06-14 at 8 34 12 PM" src="https://github.com/quantcdn/drupal/assets/282024/7973f285-c2f3-42ff-9012-dac871f54693">

---
<img width="691" alt="Screen Shot 2023-06-14 at 8 34 28 PM" src="https://github.com/quantcdn/drupal/assets/282024/60806f6c-51c4-4523-aac8-cc622b866ee4">

---
<img width="697" alt="Screen Shot 2023-06-14 at 8 34 58 PM" src="https://github.com/quantcdn/drupal/assets/282024/bd4d99b8-3217-4823-89d6-9809cf466659">

---
<img width="732" alt="Screen Shot 2023-06-14 at 8 34 41 PM" src="https://github.com/quantcdn/drupal/assets/282024/31bf3566-7cc2-4ad3-8840-adfe86a82109">
