### PR TITLE
Updated to get rid of erroneous "Strict token mismatch" logs.

### DIFF
--- a/quant.module
+++ b/quant.module
@@ -230,7 +230,7 @@ function quant_init() {
   }
 
   $path = current_path();
-  $path_alias = drupal_lookup_path('alias', $path);
+  $path_alias = drupal_get_path_alias($path);
   $strict = variable_get('quant_token_strict', true);
 
   if (quant_token_validate($path_alias, $strict)) {
@@ -1255,6 +1255,11 @@ function quant_token_validate($route, $strict = TRUE) {
 
   $expected_route = parse_url(ltrim($route, '/'), PHP_URL_PATH);
   $received_route = parse_url(ltrim($payload['route'], '/'), PHP_URL_PATH);
+
+  // Special case for home page.
+  if ($expected_route == 'node' && $received_route == '') {
+    $expected_route = '';
+  }
 
   if ($strict && $expected_route != $received_route) {
     watchdog('quant_token', 'Strict token mismatch: Expected [@expected] Received [@received]', array(


### PR DESCRIPTION
See d.o issue: https://www.drupal.org/project/quantcdn/issues/3339307

**Before**

<img width="848" alt="Screen Shot 2023-06-14 at 11 08 03 PM" src="https://github.com/quantcdn/drupal/assets/282024/f2b8e76b-ac3f-4a40-aba6-12a8fb30e631">

---
**After**

<img width="834" alt="Screen Shot 2023-06-14 at 11 07 01 PM" src="https://github.com/quantcdn/drupal/assets/282024/6a8ffd28-c52a-4675-a6ac-ae2fb848d758">
