### PR TITLE
Add hook_help to all modules.

### DIFF
--- a/modules/quant_api/quant_api.module
+++ b/modules/quant_api/quant_api.module
@@ -15,8 +15,11 @@ define('QUANT_API_ENDPOINT_DEFAULT', 'https://api.quantcdn.io');
 /**
  * Implements hook_help().
  */
-function quant_api_help() {
-  // @TODO.
+function quant_api_help($section) {
+  switch ($section) {
+    case 'admin/help#quant_api':
+      return quant_help('admin/help#quant');
+  }
 }
 
 /**

--- a/modules/quant_cron/quant_cron.module
+++ b/modules/quant_cron/quant_cron.module
@@ -6,6 +6,16 @@
  */
 
 /**
+ * Implements hook_help().
+ */
+function quant_cron_help($section) {
+  switch ($section) {
+    case 'admin/help#quant_cron':
+      return quant_help('admin/help#quant');
+  }
+}
+
+/**
  * Implements hook_menu().
  */
 function quant_cron_menu() {

--- a/modules/quant_file/quant_file.info
+++ b/modules/quant_file/quant_file.info
@@ -2,7 +2,7 @@ name = Quant File
 description = Publish file displays to Quant
 package = Quant
 core = 7.x
-configure = admin/config/service/quant/seed
+configure = admin/config/services/quant/seed
 
 dependencies[] = quant
 dependencies[] = quant_api

--- a/modules/quant_file/quant_file.module
+++ b/modules/quant_file/quant_file.module
@@ -6,6 +6,16 @@
  */
 
 /**
+ * Implements hook_help().
+ */
+function quant_file_help($section) {
+  switch ($section) {
+    case 'admin/help#quant_file':
+      return quant_help('admin/help#quant');
+  }
+}
+
+/**
  * Implements hook_file_insert().
  */
 function quant_file_file_insert($file) {

--- a/modules/quant_redirect/quant_redirect.module
+++ b/modules/quant_redirect/quant_redirect.module
@@ -6,6 +6,16 @@
  */
 
 /**
+ * Implements hook_help().
+ */
+function quant_redirect_help($section) {
+  switch ($section) {
+    case 'admin/help#quant_redirect':
+      return quant_help('admin/help#quant');
+  }
+}
+
+/**
  * Implements hook_form_FORM_ID_alter().
  */
 function quant_redirect_form_quant_config_alter(&$form, $form_state) {

--- a/modules/quant_scheduler/quant_scheduler.info
+++ b/modules/quant_scheduler/quant_scheduler.info
@@ -2,5 +2,7 @@ name = Quant scheduler
 description = Support scheduler transitions.
 package = Quant
 core = 7.x
+configure = admin/config/content/scheduler
+
 dependencies[] = quant
 dependencies[] = scheduler

--- a/modules/quant_scheduler/quant_scheduler.module
+++ b/modules/quant_scheduler/quant_scheduler.module
@@ -6,6 +6,16 @@
  */
 
 /**
+ * Implements hook_help().
+ */
+function quant_scheduler_help($section) {
+  switch ($section) {
+    case 'admin/help#quant_scheduler':
+      return quant_help('admin/help#quant');
+  }
+}
+
+/**
  * Implements hook_quant_meta_alter().
  */
 function quant_scheduler_quant_meta_alter(&$meta, $context) {

--- a/modules/quant_sitemap/quant_sitemap.module
+++ b/modules/quant_sitemap/quant_sitemap.module
@@ -6,6 +6,16 @@
  */
 
 /**
+ * Implements hook_help().
+ */
+function quant_sitemap_help($section) {
+  switch ($section) {
+    case 'admin/help#quant_sitemap':
+      return quant_help('admin/help#quant');
+  }
+}
+
+/**
  * Implements hook_form_FORM_ID_alter().
  */
 function quant_sitemap_form_quant_seed_settings_alter(&$form, $form_state) {

--- a/quant.module
+++ b/quant.module
@@ -23,12 +23,54 @@ module_load_include('inc', 'quant', 'quant_queue_class');
  * Implements hook_help().
  */
 function quant_help($section) {
-  switch ($section) {
-    case 'quant/config':
-      return '';
 
-    case 'quant/api':
-      return '';
+    $enabled = [];
+    $modules = ['quant', 'quant_api', 'quant_cron', 'quant_file', 'quant_redirect', 'quant_scheduler', 'quant_sitemap'];
+    foreach ($modules as $module) {
+      $enabled[$module] = module_exists($module) ? t('(Enabled)') : t('(Disabled)');
+    }
+
+  // Technically, the help text for each module should be in the module, but we
+  // are using the same text for everything, so this makes it simpler.
+  $help_summary = t('The <a href="https://www.drupal.org/project/quantcdn">Quant module</a> integrates your Drupal site with <a href="https://www.quantcdn.io">QuantCDN</a> to create a static version of your website.');
+  switch ($section) {
+    case 'admin/config/services/quant':
+    case 'admin/config/services/quant/api':
+    case 'admin/config/services/quant/cron':
+    case 'admin/config/services/quant/queue':
+    case 'admin/config/services/quant/seed':
+    case 'admin/config/services/quant/token':
+      return $help_summary . ' <a href="/admin/help/quant">More info</a>' ;
+
+    case 'admin/help#quant':
+      $output = '<h3>' . t('About') . '</h3>';
+      $output .= '<p>' . $help_summary . '</p>';
+      $output .= '<p>' . t('You can learn more in the <a href="https://docs.quantcdn.io/docs/integrations/drupal">Quant Drupal integration documentation</a>.') . '</p>';
+      $output .= '<h3>' . t('Quant modules') . '</h3>';
+      $output .= '<ul>';
+      $output .= '<li><strong>Quant</strong> ' . $enabled['quant'] . ' - Main Quant module with general, seed, and token settings.</li>';
+      $output .= '<li><strong>Quant API</strong> ' . $enabled['quant_api'] . ' - API module to connect your Drupal site with your Quant project.</li>';
+      $output .= '<li><strong>Quant Cron</strong> ' . $enabled['quant_cron'] . ' - Cron module for syncing content during cron runs.</li>';
+      $output .= '<li><strong>Quant File*</strong> ' . $enabled['quant_file'] . ' - File module to sync file displays to Quant.</li>';
+      $output .= '<li><strong>Quant Redirect*</strong> ' . $enabled['quant_redirect'] . ' - Redirect module to sync redirects to Quant.</li>';
+      $output .= '<li><strong>Quant Scheduler*</strong> ' . $enabled['quant_scheduler'] . ' - Scheduler module to support scheduler transitions.</li>';
+      $output .= '<li><strong>Quant Sitemap*</strong> ' . $enabled['quant_sitemap'] . ' - Sitemap module to sync XML sitemaps to Quant.</li>';
+      $output .= '<p>Note: * indicates the module has no specific configuration page though there may be settings on other admin pages.</p>';
+      $output .= '</ul>';
+      $output .= '<h3>' . t('Quant menu') . '</h3>';
+      $output .= '<ul>';
+      $output .= '<li><a href="/admin/config/services/quant">Quant Config</a></li>';
+      if (module_exists('quant_api')) {
+        $output .= '<li><a href="/admin/config/services/quant/api">Quant API</a></li>';
+      }
+      if (module_exists('quant_cron')) {
+        $output .= '<li><a href="/admin/config/services/quant/cron">Quant Cron</a></li>';
+      }
+      $output .= '<li><a href="/admin/config/services/quant/queue">Quant Queue</a></li>';
+      $output .= '<li><a href="/admin/config/services/quant/seed">Quant Seed</a></li>';
+      $output .= '<li><a href="/admin/config/services/quant/token">Quant Token</a></li>';
+      $output .= '</ul>';
+      return $output;
   }
 }
 


### PR DESCRIPTION
See d.o issue: https://www.drupal.org/project/quantcdn/issues/3366892

Also cleaned up a couple of module configure links in the info files.

Note, the "Quant administration pages" on the bottom of the help page come from the core system and can't be overridden, so I added a "Quant menu" section to include the additional tabs.

**Before**

---
<img width="1110" alt="Screen Shot 2023-06-14 at 3 28 26 PM" src="https://github.com/quantcdn/drupal/assets/282024/9d33050b-2e08-4111-be6e-fc68154cb634">

---
<img width="884" alt="Screen Shot 2023-06-15 at 12 01 27 PM" src="https://github.com/quantcdn/drupal/assets/282024/248b043e-f9e6-4bac-ad3b-7687c5210956">

---
**After**

<img width="1073" alt="Screen Shot 2023-06-15 at 11 59 20 AM" src="https://github.com/quantcdn/drupal/assets/282024/36281834-0f94-42a8-a16b-0ec04c9ec573">

---
<img width="854" alt="Screen Shot 2023-06-15 at 11 59 39 AM" src="https://github.com/quantcdn/drupal/assets/282024/3e4af42b-e18c-4645-9a0a-c209eefde758">

---
<img width="1118" alt="Screen Shot 2023-06-15 at 11 59 54 AM" src="https://github.com/quantcdn/drupal/assets/282024/26632f5b-589e-4480-9d58-a53a023ab7ef">
