### PR TITLE
Add clear queue button to seed form and align buttons.

### DIFF
--- a/quant.admin.inc
+++ b/quant.admin.inc
@@ -287,11 +287,18 @@ function quant_seed_settings() {
   $form['actions']['#weight'] = 998;
   $form['actions']['submit']['#validate'][] = 'quant_form_quant_seed_validate';
 
-  $form['save_and_queue'] = array(
+  $form['actions']['save_and_queue'] = array(
     '#type' => 'submit',
     '#value' => 'Save and Queue',
     '#submit' => array('system_settings_form_submit', '_quant_queue_batch'),
     '#weight' => 999,
+  );
+
+  $form['actions']['clear_queue'] = array(
+    '#type' => 'submit',
+    '#value' => 'Clear Queue',
+    '#submit' => array('system_settings_form_submit', '_quant_queue_clear'),
+    '#weight' => 9999,
   );
 
   return $form;

--- a/quant.module
+++ b/quant.module
@@ -1058,6 +1058,15 @@ function _quant_queue_batch() {
 }
 
 /**
+ * Clear the queue.
+ */
+function _quant_queue_clear() {
+  $queue = quant_get_queue();
+  $queue->deleteQueue();
+  drupal_set_message(t('The queue has been cleared.'), 'status');
+}
+
+/**
  * Batch handler to process the Quant seed queue.
  */
 function quant_batch_process_queue($queue_name, &$context) {


### PR DESCRIPTION
See d.o issue: https://www.drupal.org/project/quantcdn/issues/3367121

Note, it would be better UX to add on the Queue tab but, it's more work, so better to have it somewhere and this is the next best choice.

**Before**

---

<img width="522" alt="Screen Shot 2023-06-15 at 1 28 16 PM" src="https://github.com/quantcdn/drupal/assets/282024/e0ca94b6-69ac-4c21-af86-b45163efef5a">

---

<img width="822" alt="Screen Shot 2023-06-15 at 1 29 42 PM" src="https://github.com/quantcdn/drupal/assets/282024/dc0539ad-b30c-474d-b011-90a9b8d8d8a1">

**After**

---

<img width="509" alt="Screen Shot 2023-06-15 at 1 27 36 PM" src="https://github.com/quantcdn/drupal/assets/282024/439ef9da-aacf-4a98-a2cd-a011b01f0702">

---

<img width="526" alt="Screen Shot 2023-06-15 at 1 27 49 PM" src="https://github.com/quantcdn/drupal/assets/282024/c5ac83ae-1366-4054-b156-cf5be2ab0b8d">

---

<img width="835" alt="Screen Shot 2023-06-15 at 1 30 06 PM" src="https://github.com/quantcdn/drupal/assets/282024/5a9b5be2-1398-4d59-8f16-75abc83ea04f">
