### PR TITLE
Ensure base_url is pulled from the form_state value.

### DIFF
--- a/quant.admin.inc
+++ b/quant.admin.inc
@@ -150,7 +150,7 @@ function quant_config() {
  * Validate the configuration form to ensure that the settings are valid.
  */
 function quant_form_quant_config_validate($form = array(), &$form_state = array()) {
-  $base = quant_get_base_url();
+  $base = $form_state['values']['quant_base_url'];
 
   // Check hostname is a valid domain.
   $quant_hostname = trim($form_state['values']['quant_hostname']);


### PR DESCRIPTION
The validation function is not accounting for the value passed in the form, can mean config values cannot be saved on fresh installations if the default value fails validation.