### PR TITLE
Handle circular dependency between quant and quant_api.

### DIFF
--- a/modules/quant_api/quant_api.info
+++ b/modules/quant_api/quant_api.info
@@ -3,3 +3,4 @@ description = Quant API exporter
 package = Quant
 core = 7.x
 configure = admin/config/services/quant/api
+; Do not add quant:quant as a dependency here. See quant_api_enable().

--- a/modules/quant_api/quant_api.module
+++ b/modules/quant_api/quant_api.module
@@ -13,6 +13,15 @@
 define('QUANT_API_ENDPOINT_DEFAULT', 'https://api.quantcdn.io');
 
 /**
+ * Implements hook_enable().
+ */
+function quant_api_enable() {
+  // To avoid a circular dependency which will prevent uninstalling, enable the
+  // Quant module here instead of adding it as a dependency in the info file.
+  module_enable(array('quant'));
+}
+
+/**
  * Implements hook_help().
  */
 function quant_api_help($section) {

--- a/modules/quant_api/quant_api.module
+++ b/modules/quant_api/quant_api.module
@@ -18,7 +18,15 @@ define('QUANT_API_ENDPOINT_DEFAULT', 'https://api.quantcdn.io');
 function quant_api_enable() {
   // To avoid a circular dependency which will prevent uninstalling, enable the
   // Quant module here instead of adding it as a dependency in the info file.
-  module_enable(array('quant'));
+  $success = module_enable(array('quant'));
+  $message = $success ? 'QuantAPI: The quant module was enabled successfully.' : 'QuantAPI: The quant module could not be enabled. Try enabling it manually.';
+  if (drupal_is_cli()) {
+    // phpcs:ignore
+    drush_log(t($message));
+  }
+  else {
+    drupal_set_message(t($message));
+  }
 }
 
 /**
@@ -27,7 +35,7 @@ function quant_api_enable() {
 function quant_api_help($section) {
   switch ($section) {
     case 'admin/help#quant_api':
-      return quant_help('admin/help#quant');
+      return function_exists('quant_help') ? quant_help('admin/help#quant') : '<p>Install the Quant module for help text.</p>';
   }
 }
 


### PR DESCRIPTION
See d.o issue: https://www.drupal.org/project/quantcdn/issues/3375407

Testing results:

```
Kristens-MacBook-Pro:quant_api kristenpol$ ddev drush pm:list |grep quant
 Quant             Quant (quant)                                                Module  Not installed              
 Quant             Quant API (quant_api)                                        Module  Not installed              
 Quant             Quant Cron (quant_cron)                                      Module  Not installed              
 Quant             Quant File (quant_file)                                      Module  Not installed              
 Quant             Quant Redirects (quant_redirect)                             Module  Not installed              
 Quant             Quant scheduler (quant_scheduler)                            Module  Not installed              
 Quant             Quant sitemap (quant_sitemap)                                Module  Not installed              
Kristens-MacBook-Pro:quant_api kristenpol$ ddev drush pm:enable quant_api -y
The following extensions will be enabled: quant_api
Do you really want to continue? (y/n): y
quant_api was enabled successfully.                                                                                                                                     [ok]
Kristens-MacBook-Pro:quant_api kristenpol$ ddev drush pm:list |grep quant
 Quant             Quant (quant)                                                Module  Enabled                    
 Quant             Quant API (quant_api)                                        Module  Enabled                    
 Quant             Quant Cron (quant_cron)                                      Module  Not installed              
 Quant             Quant File (quant_file)                                      Module  Not installed              
 Quant             Quant Redirects (quant_redirect)                             Module  Not installed              
 Quant             Quant scheduler (quant_scheduler)                            Module  Not installed              
 Quant             Quant sitemap (quant_sitemap)                                Module  Not installed              
Kristens-MacBook-Pro:quant_api kristenpol$ ddev drush pm:disable quant_api -y
The following extensions will be disabled: quant_api, quant
Do you really want to continue? (y/n): y
quant was disabled successfully.                                                                                                                                        [ok]
quant_api was disabled successfully.                                                                                                                                    [ok]
Kristens-MacBook-Pro:quant_api kristenpol$ ddev drush pm:list |grep quant
 Quant             Quant (quant)                                                Module  Disabled                   
 Quant             Quant API (quant_api)                                        Module  Disabled                   
 Quant             Quant Cron (quant_cron)                                      Module  Not installed              
 Quant             Quant File (quant_file)                                      Module  Not installed              
 Quant             Quant Redirects (quant_redirect)                             Module  Not installed              
 Quant             Quant scheduler (quant_scheduler)                            Module  Not installed              
 Quant             Quant sitemap (quant_sitemap)                                Module  Not installed              
Kristens-MacBook-Pro:quant_api kristenpol$ ddev drush pm:uninstall quant_api -y
To uninstall quant_api, the following modules must be uninstalled first: quant                                                                                          [error]
There were no modules that could be uninstalled.                                                                                                                        [ok]
Kristens-MacBook-Pro:quant_api kristenpol$ ddev drush pm:uninstall quant -y
The following modules will be uninstalled: quant
Do you really want to continue? (y/n): y
quant was successfully uninstalled.                                                                                                                                     [ok]
Kristens-MacBook-Pro:quant_api kristenpol$ ddev drush pm:uninstall quant_api -y
The following modules will be uninstalled: quant_api
Do you really want to continue? (y/n): y
quant_api was successfully uninstalled.                                                                                                                                 [ok]
```