### PR TITLE
DRAFT Drupal 11 compatibility.

### DIFF
--- a/modules/quant_api/quant_api.info.yml
+++ b/modules/quant_api/quant_api.info.yml
@@ -3,7 +3,7 @@ description: Connect to the hosted Quant service
 package: Quant
 
 type: module
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^9.3 || ^10 || ^11
 configure: quant_api.settings_form
 dependencies:
   - drupal:quant

--- a/modules/quant_api/src/Form/SettingsForm.php
+++ b/modules/quant_api/src/Form/SettingsForm.php
@@ -107,6 +107,12 @@ class SettingsForm extends ConfigFormBase {
   /**
    * {@inheritdoc}
    */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function submitForm(array &$form, FormStateInterface $form_state) {
 
     // Retrieve the configuration.

--- a/modules/quant_cron/quant_cron.info.yml
+++ b/modules/quant_cron/quant_cron.info.yml
@@ -3,7 +3,7 @@ description: Run Quant tasks during cron
 package: Quant
 
 type: module
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^9.3 || ^10 || ^11
 configure: quant_cron.settings_form
 dependencies:
   - quant:quant_api

--- a/modules/quant_purger/quant_purger.info.yml
+++ b/modules/quant_purger/quant_purger.info.yml
@@ -3,7 +3,7 @@ description: Cache tag purger for Quant.
 package: Quant
 
 type: module
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^9.3 || ^10 || ^11
 
 dependencies:
   - quant:quant

--- a/modules/quant_purger/src/StackMiddleware/UrlRegistrar.php
+++ b/modules/quant_purger/src/StackMiddleware/UrlRegistrar.php
@@ -57,7 +57,7 @@ if (empty($method->getReturnType())) {
     /**
      * {@inheritdoc}
      */
-    public function handle(Request $request, $type = self::MASTER_REQUEST, $catch = TRUE) {
+    public function handle(Request $request, $type = self::MAIN_REQUEST, $catch = TRUE) {
       $response = $this->httpKernel->handle($request, $type, $catch);
       if ($this->determine($request, $response)) {
         $this->registry->add(

--- a/modules/quant_search/quant_search.info.yml
+++ b/modules/quant_search/quant_search.info.yml
@@ -3,7 +3,7 @@ description: 'Allows creation of Quant Search pages.'
 package: Quant
 
 type: module
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^9.3 || ^10 || ^11
 configure: quant_search.main
 dependencies:
   - drupal:quant

--- a/modules/quant_sitemap/quant_sitemap.info.yml
+++ b/modules/quant_sitemap/quant_sitemap.info.yml
@@ -3,7 +3,7 @@ description: Quant simple_sitemap support
 package: Quant
 
 type: module
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^9.3 || ^10 || ^11
 
 dependencies:
   - quant:quant_api

--- a/modules/quant_tome/quant_tome.info.yml
+++ b/modules/quant_tome/quant_tome.info.yml
@@ -3,7 +3,7 @@ description: 'Deploy Tome static output to Quant.'
 package: Quant
 
 type: module
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^9.3 || ^10 || ^11
 
 dependencies:
 - tome:tome_static

--- a/modules/quant_webform/quant_webform.info.yml
+++ b/modules/quant_webform/quant_webform.info.yml
@@ -3,7 +3,7 @@ description: Quant Form support for Webform
 package: Quant
 
 type: module
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^9.3 || ^10 || ^11
 
 dependencies:
   - quant:quant

--- a/quant.info.yml
+++ b/quant.info.yml
@@ -3,7 +3,7 @@ description: Quant content export
 package: Quant
 
 type: module
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^9.3 || ^10 || ^11
 configure: quant.config
 dependencies:
   - quant:quant_api

--- a/src/Plugin/QueueItem/FileItem.php
+++ b/src/Plugin/QueueItem/FileItem.php
@@ -25,6 +25,12 @@ class FileItem implements QuantQueueItemInterface {
     $this->file = $data['file'];
     $this->url = $data['url'] ?? NULL;
     $this->fullPath = $data['full_path'] ?? NULL;
+
+    // Handle responsive images by removing extraneous data like ` 1x`.
+    if ($this->fullPath) {
+      $tmp = explode(' ', $this->fullPath, 2);
+      $this->fullPath = $tmp[0];
+    }
   }
 
   /**

--- a/src/Plugin/QueueItem/FileItem.php
+++ b/src/Plugin/QueueItem/FileItem.php
@@ -27,6 +27,7 @@ class FileItem implements QuantQueueItemInterface {
     $this->fullPath = $data['full_path'] ?? NULL;
 
     // Handle responsive images by removing extraneous data like ` 1x`.
+    // @todo Fix this in the Quant infrastructure.
     if ($this->fullPath) {
       $tmp = explode(' ', $this->fullPath, 2);
       $this->fullPath = $tmp[0];


### PR DESCRIPTION
We shouldn't merge this yet because some of our dependencies are D11 compatible yet. Moving this to draft for now.

https://www.drupal.org/project/simple_sitemap - not compatible asf 5 Jul 2024 [[D11 issue](https://www.drupal.org/project/simple_sitemap/issues/3434566)]
https://www.drupal.org/project/tome - not compatible as of 5 Jul 2024 [[D11 issue](https://www.drupal.org/project/tome/issues/3435061)]
https://www.drupal.org/project/webform - not compatible as of 5 Jul 2024 [[D11 issue](https://www.drupal.org/project/webform/issues/3452085)]
https://www.drupal.org/project/token - dev version is compatible as of 18 May 2024
https://www.drupal.org/project/purge - compatible as of 28 Jun 2024

Although we don't need to provide D11 support yet, there are quite a few modules that already do support D11. Someone provided a patch so I decided to test it. It worked with one minor tweak.

See d.o issue: https://www.drupal.org/project/quantcdn/issues/3389070