### PR TITLE
Harden content drafts and force-disable drafts when coupled with `workbench_moderation`

### DIFF
--- a/config/install/quant.settings.yml
+++ b/config/install/quant.settings.yml
@@ -5,4 +5,5 @@ quant_enabled_views: 1
 quant_enabled_redirects: 1
 quant_routes_export:
 ssl_cert_verify: 1
+disable_content_drafts: 1
 xpath_selectors: "//li[contains(@class,\"pager__item--next\")]/a[contains(@href,\"page=\")]\r\n//li[contains(@class,\"pager__item--first\")]/a[starts-with(@href, \"/\")]"

--- a/quant.install
+++ b/quant.install
@@ -86,3 +86,14 @@ function quant_update_9004(&$sandbox) {
   $config->set('xpath_selectors', implode(PHP_EOL, $xpaths));
   $config->save();
 }
+
+/**
+ * Disables draft revisions if workbench moderation is in use.
+ */
+function quant_update_9005(&$sandbox) {
+  if (\Drupal::moduleHandler()->moduleExists('workbench_moderation')) {
+    $config = \Drupal::configFactory()->getEditable('quant.settings');
+    $config->set('disable_content_drafts', 1);
+    $config->save();
+  }
+}

--- a/quant.install
+++ b/quant.install
@@ -88,7 +88,7 @@ function quant_update_9004(&$sandbox) {
 }
 
 /**
- * Disables draft revisions if workbench moderation is in use.
+ * Disables draft content handling if Workbench Moderation is installed.
  */
 function quant_update_9005(&$sandbox) {
   if (\Drupal::moduleHandler()->moduleExists('workbench_moderation')) {

--- a/quant.module
+++ b/quant.module
@@ -367,9 +367,8 @@ function quant_modules_installed($modules) {
     if (!$disabled) {
       $config->set('disable_content_drafts', 1);
       $config->save();
-      $message = 'Quant draft content handling has been disabled because the Workbench Moderation module has been installed.';
-      \Drupal::messenger()->addMessage(t($message));
-      \Drupal::logger('quant')->notice($message);
+      \Drupal::messenger()->addMessage(t('Quant draft content handling has been disabled because the Workbench Moderation module has been installed.'));
+      \Drupal::logger('quant')->notice('Quant draft content handling has been disabled because the Workbench Moderation module has been installed.');
     }
   }
 }
@@ -383,9 +382,8 @@ function quant_modules_uninstalled($modules) {
     $disabled = $config->get('disable_content_drafts');
     // Only show message if disabled.
     if ($disabled) {
-      $message = 'Quant draft content handling can be enabled now that the Workbench Moderation module has been uninstalled.';
-      \Drupal::messenger()->addMessage(t($message));
-      \Drupal::logger('quant')->notice($message);
+      \Drupal::messenger()->addMessage(t('Quant draft content handling can be enabled now that the Workbench Moderation module has been uninstalled.'));
+      \Drupal::logger('quant')->notice('Quant draft content handling can be enabled now that the Workbench Moderation module has been uninstalled.');
     }
   }
 }

--- a/quant.module
+++ b/quant.module
@@ -354,3 +354,37 @@ function quant_special_pages() {
     $item->send();
   }
 }
+
+/**
+ * Implements hook_modules_installed().
+ */
+function quant_modules_installed($modules) {
+  if (in_array('workbench_moderation', $modules)) {
+    $config = \Drupal::configFactory()->getEditable('quant.settings');
+    $disabled = $config->get('disable_content_drafts');
+    // Only disable if not already disabled.
+    if (!$disabled) {
+      $config->set('disable_content_drafts', 1);
+      $config->save();
+      $message = 'Quant draft content handling has been disabled because the Workbench Moderation module has been installed.';
+      \Drupal::messenger()->addMessage(t($message));
+      \Drupal::logger('quant')->notice($message);
+    }
+  }
+}
+
+/**
+ * Implements hook_modules_uninstalled().
+ */
+function quant_modules_uninstalled($modules) {
+  if (in_array('workbench_moderation', $modules)) {
+    $config = \Drupal::configFactory()->getEditable('quant.settings');
+    $disabled = $config->get('disable_content_drafts');
+    // Only show message if disabled.
+    if ($disabled) {
+      $message = 'Quant draft content handling can be enabled now that the Workbench Moderation module has been uninstalled.';
+      \Drupal::messenger()->addMessage(t($message));
+      \Drupal::logger('quant')->notice($message);
+    }
+  }
+}

--- a/quant.module
+++ b/quant.module
@@ -172,7 +172,8 @@ function quant_shutdown(array $context = []) {
 function quant_node_access(NodeInterface $node, $op, AccountInterface $account) {
   $request = \Drupal::request();
 
-  if (!$request->headers->has('quant-revision') && !$request->headers->has('quant-token')) {
+  // Both revision & token headers need to be present to alter access.
+  if (!$request->headers->has('quant-revision') || !$request->headers->has('quant-token')) {
     return AccessResult::neutral();
   }
 

--- a/src/Form/ConfigForm.php
+++ b/src/Form/ConfigForm.php
@@ -111,6 +111,13 @@ class ConfigForm extends ConfigFormBase {
       '#default_value' => $config->get('disable_content_drafts'),
     ];
 
+    // Ensure content drafts are disabled when workbench_moderation is in use.
+    if (\Drupal::moduleHandler()->moduleExists('workbench_moderation')) {
+      \Drupal::messenger()->addWarning(t('Workbench Moderation is in use. Drafts are currently not supported.'));
+      $form['disable_content_drafts']['#default_value'] = 1;
+      $form['disable_content_drafts']['#attributes'] = ['disabled' => 'disabled'];
+    }
+
     $form['proxy_override'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Override existing proxies'),

--- a/src/Seed.php
+++ b/src/Seed.php
@@ -434,8 +434,8 @@ class Seed {
 
     $headers['Host'] = $hostname;
 
-    // Generate a signed token and use it in the request.
-    // This only applies when drafts are enabled, as we return neutral access otherwise.
+    // Generate a signed token and use it in the request. This only applies when
+    // drafts are enabled, as we return neutral access otherwise.
     $disable_drafts = $config->get('disable_content_drafts');
     if (!$disable_drafts) {
       $headers['quant-token'] = \Drupal::service('quant.token_manager')->create($route);
@@ -494,8 +494,8 @@ class Seed {
 
     $headers['Host'] = $hostname;
 
-    // Generate a signed token and use it in the request.
-    // This only applies when drafts are enabled, as we return neutral access otherwise.
+    // Generate a signed token and use it in the request. This only applies when
+    // drafts are enabled, as we return neutral access otherwise.
     $disable_drafts = $config->get('disable_content_drafts');
     if (!$disable_drafts) {
       $headers['quant-token'] = \Drupal::service('quant.token_manager')->create($route);

--- a/src/Seed.php
+++ b/src/Seed.php
@@ -435,7 +435,11 @@ class Seed {
     $headers['Host'] = $hostname;
 
     // Generate a signed token and use it in the request.
-    $headers['quant-token'] = \Drupal::service('quant.token_manager')->create($route);
+    // This only applies when drafts are enabled, as we return neutral access otherwise.
+    $disable_drafts = $config->get('disable_content_drafts');
+    if (!$disable_drafts) {
+      $headers['quant-token'] = \Drupal::service('quant.token_manager')->create($route);
+    }
 
     // Support basic auth if enabled (note: will not work via drush/cli).
     $auth = !empty($_SERVER['PHP_AUTH_USER']) ? [
@@ -491,7 +495,11 @@ class Seed {
     $headers['Host'] = $hostname;
 
     // Generate a signed token and use it in the request.
-    $headers['quant-token'] = \Drupal::service('quant.token_manager')->create($route);
+    // This only applies when drafts are enabled, as we return neutral access otherwise.
+    $disable_drafts = $config->get('disable_content_drafts');
+    if (!$disable_drafts) {
+      $headers['quant-token'] = \Drupal::service('quant.token_manager')->create($route);
+    }
 
     // Support basic auth if enabled (note: will not work via drush/cli).
     $auth = !empty($_SERVER['PHP_AUTH_USER']) ? [

--- a/src/TokenManager.php
+++ b/src/TokenManager.php
@@ -157,9 +157,9 @@ class TokenManager {
     }
 
     if ($this->quantSettings->get('disable_content_drafts')) {
-      // When content drafts are disabled the token is irrelevant.
-      // It may not even be included in the internal HTTP request.
-      // Bypass validation altogether, as the token is only required for draft access.
+      // When content drafts are disabled the token is irrelevant. It may not
+      // even be included in the internal HTTP request. Bypass validation
+      // altogether, as the token is only required for draft access.
       throw new TokenValidationDisabledException();
     }
 

--- a/src/TokenManager.php
+++ b/src/TokenManager.php
@@ -39,6 +39,13 @@ class TokenManager {
   protected $settings;
 
   /**
+   * Global Quant configuration.
+   *
+   * @var \Drupal\Core\Config\ImmutableConfig
+   */
+  protected $quantSettings;
+
+  /**
    * Construct a TokenManager instance.
    *
    * @param \Drupal\Core\Database\Connection $connection
@@ -52,6 +59,7 @@ class TokenManager {
     $this->connection = $connection;
     $this->request = $request;
     $this->settings = $config_factory->get('quant.token_settings');
+    $this->quantSettings = $config_factory->get('quant.settings');
   }
 
   /**
@@ -145,6 +153,13 @@ class TokenManager {
       // Allow administrators to completely bypass the token verification
       // process. This can be done to test server configuration and is
       // not recommended in production.
+      throw new TokenValidationDisabledException();
+    }
+
+    if ($this->quantSettings->get('disable_content_drafts')) {
+      // When content drafts are disabled the token is irrelevant.
+      // It may not even be included in the internal HTTP request.
+      // Bypass validation altogether, as the token is only required for draft access.
       throw new TokenValidationDisabledException();
     }
 


### PR DESCRIPTION
* `workbench_moderation` is not currently supported and has issues when the "disable drafts" option is not enabled
* default `disable_content_drafts` to on
* harden the use of the `quant-token` header when content drafts are disabled