### PR TITLE
Added log message when seed gets non-200 status.

### DIFF
--- a/src/Seed.php
+++ b/src/Seed.php
@@ -553,6 +553,7 @@ class Seed {
       default:
         $messenger = \Drupal::messenger();
         $messenger->addMessage("Non-200 response for {$route}: " . $response->getStatusCode(), $messenger::TYPE_WARNING);
+        \Drupal::logger('quant_seed')->notice("Non-200 response for {$route}: " . $response->getStatusCode());
         return FALSE;
     }
 


### PR DESCRIPTION
Added this while debugging because the message doesn't show up in the UI:

https://www.drupal.org/project/quantcdn/issues/3344492
https://www.drupal.org/project/quantcdn/issues/3399179

I haven't been able to figure out how to fix those but this one-liner can get merged.

Drupal.org issue: https://www.drupal.org/project/quantcdn/issues/3399265

![Screenshot 2023-11-05 at 2 09 48 PM](https://github.com/quantcdn/drupal/assets/282024/69430d93-e9a8-4188-a3c1-4f2b79f56771)

