### PR TITLE
Added code to handle unpublishing path aliases.

### DIFF
--- a/modules/quant_api/src/EventSubscriber/QuantApi.php
+++ b/modules/quant_api/src/EventSubscriber/QuantApi.php
@@ -309,7 +309,10 @@ class QuantApi implements EventSubscriberInterface {
       $res = $this->client->unpublish($url);
     }
     catch (\Exception $error) {
-      $this->logger->error($error->getMessage());
+      // Don't log it if it's a 404, since the content is unpublished.
+      if (strpos($error, '404 Not Found') === false) {
+        $this->logger->error($error->getMessage());
+      }
       return;
     }
 

--- a/modules/quant_api/src/EventSubscriber/QuantApi.php
+++ b/modules/quant_api/src/EventSubscriber/QuantApi.php
@@ -2,18 +2,18 @@
 
 namespace Drupal\quant_api\EventSubscriber;
 
+use Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\quant\Event\QuantEvent;
 use Drupal\quant\Event\QuantFileEvent;
 use Drupal\quant\Event\QuantRedirectEvent;
-use Drupal\quant_api\Client\QuantClientInterface;
-use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Drupal\quant_api\Exception\InvalidPayload;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher;
 use Drupal\quant\Plugin\QueueItem\FileItem;
 use Drupal\quant\Plugin\QueueItem\RouteItem;
-use Drupal\quant\Seed;
 use Drupal\quant\QuantQueueFactory;
+use Drupal\quant\Seed;
+use Drupal\quant_api\Client\QuantClientInterface;
+use Drupal\quant_api\Exception\InvalidPayload;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * Integrate with the QuantAPI to store static assets.
@@ -310,7 +310,7 @@ class QuantApi implements EventSubscriberInterface {
     }
     catch (\Exception $error) {
       // Don't log it if it's a 404, since the content is unpublished.
-      if (strpos($error, '404 Not Found') === false) {
+      if (strpos($error->getMessage(), '404 Not Found') === false) {
         $this->logger->error($error->getMessage());
       }
       return;

--- a/modules/quant_api/src/EventSubscriber/QuantApi.php
+++ b/modules/quant_api/src/EventSubscriber/QuantApi.php
@@ -310,7 +310,7 @@ class QuantApi implements EventSubscriberInterface {
     }
     catch (\Exception $error) {
       // Don't log it if it's a 404, since the content is unpublished.
-      if (strpos($error->getMessage(), '404 Not Found') === false) {
+      if (strpos($error->getMessage(), '404 Not Found') === FALSE) {
         $this->logger->error($error->getMessage());
       }
       return;

--- a/quant.module
+++ b/quant.module
@@ -6,15 +6,15 @@
  */
 
 use Drupal\Core\Access\AccessResult;
-use Drupal\Core\Session\AccountInterface;
-use Drupal\node\NodeInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
+use Drupal\node\NodeInterface;
 use Drupal\quant\Exception\TokenValidationDisabledException;
 use Drupal\quant\Plugin\QueueItem\RouteItem;
-use Drupal\quant\Seed;
 use Drupal\quant\QuantQueueFactory;
+use Drupal\quant\Seed;
 
 /**
  * Implements hook_menu_local_tasks_alter().
@@ -273,6 +273,10 @@ function _quant_entity_delete_op(EntityInterface $entity) {
       Seed::unpublishNode($entity);
       break;
 
+    case 'path_alias':
+      Seed::unpublishPathAlias($entity);
+      break;
+
     case 'taxonomy_term':
       Seed::unpublishTaxonomyTerm($entity);
       break;
@@ -385,5 +389,28 @@ function quant_modules_uninstalled($modules) {
       \Drupal::messenger()->addMessage(t('Quant draft content handling can be enabled now that the Workbench Moderation module has been uninstalled.'));
       \Drupal::logger('quant')->notice('Quant draft content handling can be enabled now that the Workbench Moderation module has been uninstalled.');
     }
+  }
+}
+
+/**
+ * Unpublish old alias if it changes.
+ *
+ * @param Drupal\Core\Entity\EntityInterface $pathAlias
+ *   The path alias.
+ */
+function quant_path_alias_presave(EntityInterface $pathAlias) {
+  // Original path alias.
+  $original_path = $pathAlias->original->get('path')->value;
+  $original_alias = $pathAlias->original->get('alias')->value;
+  $original_langcode = $pathAlias->original->get('langcode')->value;
+
+  // Current path alias.
+  $path = $pathAlias->get('path')->value;
+  $alias = $pathAlias->get('alias')->value;
+  $langcode = $pathAlias->get('langcode')->value;
+
+  // Unpublish original alias if it changed.
+  if ($original_path == $path && $langcode == $original_langcode && $original_alias != $alias) {
+    Seed::unpublishPathAlias($pathAlias->original);
   }
 }

--- a/src/Seed.php
+++ b/src/Seed.php
@@ -438,6 +438,22 @@ class Seed {
   }
 
   /**
+   * Unpublish path alias via API request.
+   */
+  public static function unpublishPathAlias($pathAlias) {
+
+    $alias = $pathAlias->get('alias')->value;
+
+    // Handle multilingual paths.
+    if (self::usesLanguagePathPrefixes()) {
+      $langcode = $pathAlias->get('langcode')->value;
+      $alias = $langcode . '/' . $alias;
+    }
+
+    \Drupal::service('event_dispatcher')->dispatch(new QuantEvent('', $alias, [], NULL), QuantEvent::UNPUBLISH);
+  }
+
+  /**
    * Attempts a HTTP HEAD request to a given route.
    *
    * @param string $route


### PR DESCRIPTION
See Drupal.org for details: https://www.drupal.org/project/quantcdn/issues/3404641

Note that this doesn't handle creating unpublished content with the new alias but that can be a follow up ticket as it's not as critical.

Also added code to suppress 404 error when unpublishing since the error is because the content is unpublished.