### PR TITLE
Added page info block feature.

### DIFF
--- a/config/install/quant.settings.yml
+++ b/config/install/quant.settings.yml
@@ -6,4 +6,5 @@ quant_enabled_redirects: 1
 quant_routes_export:
 ssl_cert_verify: 1
 disable_content_drafts: 1
+quant_show_page_info_block: 1
 xpath_selectors: "//li[contains(@class,\"pager__item--next\")]/a[contains(@href,\"page=\")]\r\n//li[contains(@class,\"pager__item--first\")]/a[starts-with(@href, \"/\")]\r\n//li[contains(@class,\"page-item\")]/a[contains(@href,\"page=\")]"

--- a/modules/quant_api/src/Client/QuantClient.php
+++ b/modules/quant_api/src/Client/QuantClient.php
@@ -295,6 +295,30 @@ class QuantClient implements QuantClientInterface {
   }
 
   /**
+   * Gets global metadata for the given URLs.
+   *
+   * @param array $urls
+   *   The urls to get metadata for.
+   *
+   * @return array
+   *   The API response.
+   */
+  public function getUrlMeta(array $urls) : array {
+    // @todo Switch from 'Quant-Customer' to 'Quant-Organization'.
+    $response = $this->client->post($this->endpoint . '/url-meta', [
+      RequestOptions::JSON => $urls,
+      'headers' => [
+        'Quant-Customer' => $this->username,
+        'Quant-Project'  => $this->project,
+        'Quant-Token'    => $this->token,
+      ],
+      'verify' => $this->tlsDisabled ? FALSE : TRUE,
+    ]);
+
+    return json_decode($response->getBody(), TRUE);
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function sendSearchRecords(array $records) : array {

--- a/modules/quant_api/src/Client/QuantClient.php
+++ b/modules/quant_api/src/Client/QuantClient.php
@@ -304,6 +304,12 @@ class QuantClient implements QuantClientInterface {
    *   The API response.
    */
   public function getUrlMeta(array $urls) : array {
+    // Format array if it's not already.
+    if (!array_key_exists('Quant-Url', $urls)) {
+      $urls = [
+        'Quant-Url' => $urls,
+      ];
+    }
     // @todo Switch from 'Quant-Customer' to 'Quant-Organization'.
     $response = $this->client->post($this->endpoint . '/url-meta', [
       RequestOptions::JSON => $urls,

--- a/quant.install
+++ b/quant.install
@@ -113,3 +113,12 @@ function quant_update_9006(&$sandbox) {
   $config->set('xpath_selectors', implode(PHP_EOL, $xpaths));
   $config->save();
 }
+
+/**
+ * Enables Quant setting to show page info block.
+ */
+function quant_update_9007(&$sandbox) {
+  $config = \Drupal::configFactory()->getEditable('quant.settings');
+  $config->set('quant_show_page_info_block', 1);
+  $config->save();
+}

--- a/quant.module
+++ b/quant.module
@@ -5,6 +5,7 @@
  * Hook implementations for Quant.
  */
 
+use Drupal\block\Entity\Block;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -15,6 +16,7 @@ use Drupal\quant\Exception\TokenValidationDisabledException;
 use Drupal\quant\Plugin\QueueItem\RouteItem;
 use Drupal\quant\QuantQueueFactory;
 use Drupal\quant\Seed;
+use Drupal\quant\Utility;
 
 /**
  * Implements hook_menu_local_tasks_alter().
@@ -412,5 +414,18 @@ function quant_path_alias_presave(EntityInterface $pathAlias) {
   // Unpublish original alias if it changed.
   if ($original_path == $path && $langcode == $original_langcode && $original_alias != $alias) {
     Seed::unpublishPathAlias($pathAlias->original);
+  }
+}
+
+/**
+ * Implements hook_preprocess_page().
+ */
+function quant_preprocess_page(&$variables) {
+  // Show the Quant page info block for non-admin pages if enabled.
+  $config = \Drupal::configFactory()->getEditable('quant.settings');
+  $enabled = $config->get('quant_show_page_info_block');
+
+  if ($enabled && !\Drupal::service('router.admin_context')->isAdminRoute()) {
+    $variables['page']['content']['#prefix'] = Utility::getPageInfo() . ($variables['page']['content']['#prefix'] ?? '');
   }
 }

--- a/quant.module
+++ b/quant.module
@@ -5,7 +5,6 @@
  * Hook implementations for Quant.
  */
 
-use Drupal\block\Entity\Block;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;

--- a/src/Form/ConfigForm.php
+++ b/src/Form/ConfigForm.php
@@ -111,6 +111,13 @@ class ConfigForm extends ConfigFormBase {
       '#default_value' => $config->get('disable_content_drafts'),
     ];
 
+    $form['quant_show_page_info_block'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Show page information block'),
+      '#description' => $this->t('Adds Quant page info at the top of all non-admin pages. To place this information in a block region, disable this setting and use the <a href="/admin/structure/block">core block layout UI</a> to place the <em>Quant Page Info</em> block.'),
+      '#default_value' => $config->get('quant_show_page_info_block'),
+    ];
+
     // Ensure content drafts are disabled when workbench_moderation is in use.
     if (\Drupal::moduleHandler()->moduleExists('workbench_moderation')) {
       \Drupal::messenger()->addWarning(t('Workbench Moderation is in use. Drafts are currently not supported.'));
@@ -173,6 +180,7 @@ class ConfigForm extends ConfigFormBase {
       ->set('host_domain', $form_state->getValue('host_domain'))
       ->set('host_domain_strip', $form_state->getValue('host_domain_strip'))
       ->set('disable_content_drafts', $form_state->getValue('disable_content_drafts'))
+      ->set('quant_show_page_info_block', $form_state->getValue('quant_show_page_info_block'))
       ->set('ssl_cert_verify', $form_state->getValue('ssl_cert_verify'))
       ->set('xpath_selectors', $form_state->getValue('xpath_selectors'))
       ->save();

--- a/src/Plugin/Block/QuantPageInfoBlock.php
+++ b/src/Plugin/Block/QuantPageInfoBlock.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\quant\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+use Drupal\quant\Utility;
+
+/**
+ * Provides a Quant page information block.
+ *
+ * @Block(
+ *  id = "quant_page_info_block",
+ *  admin_label = @Translation("Quant Page Info"),
+ * )
+ */
+class QuantPageInfoBlock extends BlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+
+    return [
+      '#markup' => Utility::getPageInfo(),
+      '#cache' => [
+        'max-age' => 0,
+      ],
+    ];
+  }
+
+}

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -117,7 +117,7 @@ class Utility {
       $output .= '<h2>' . t('Quant Page Info') . '</h2>';
       foreach ($response['global_meta']['records'] as $record) {
         $found_urls[] = $url = $record['meta']['url'];
-        $output .= '<div class="quant-page-info">';
+        $output .= '<div class="quant-page-info messages messages--warning">';
         $output .= '<strong>Page info for ' . $url . '</strong>';
         $output .= '<ul>';
         $output .= '<li><strong>Published</strong>: ' . ($record['meta']['published'] ? t('Yes') : t('No')) . '</li>';

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -5,7 +5,6 @@ namespace Drupal\quant;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\language\Plugin\LanguageNegotiation\LanguageNegotiationUrl;
-use Drupal\quant_api\Client\QuantClientInterface;
 
 /**
  * Quant utility class for helper functions.
@@ -14,8 +13,11 @@ class Utility {
 
   /**
    * Determine if URL path prefix language negotiation is being used.
+   *
+   * @return bool
+   *   TRUE if language path prefixes are configured and FALSE otherwise.
    */
-  public static function usesLanguagePathPrefixes() {
+  public static function usesLanguagePathPrefixes() : bool {
     // Only works if there is more than one language.
     $langcodes = \Drupal::languageManager()->getLanguages();
     if (count($langcodes) === 1) {
@@ -34,10 +36,15 @@ class Utility {
   /**
    * Get URL based on site settings.
    *
-   * @return
+   * @param string $url
+   *   The URL.
+   * @param string $langcode
+   *   The language code for the URL.
+   *
+   * @return string
    *   The URL adjusted for multilingual settings. Defaults to current url.
    */
-  public static function getUrl($url = NULL, $langcode = NULL) {
+  public static function getUrl(string $url = NULL, string $langcode = NULL) : string {
 
     // Default to current URL.
     if (!$url) {
@@ -75,7 +82,7 @@ class Utility {
    * @return bool
    *   TRUE if external and FALSE otherwise.
    */
-  public static function isExternalUrl($url) {
+  public static function isExternalUrl(string $url) : bool {
     $config = \Drupal::config('quant.settings');
     $hostname = $config->get('host_domain') ?: $_SERVER['SERVER_NAME'];
     $check_url = parse_url($url);
@@ -94,7 +101,7 @@ class Utility {
    * @return string
    *   The markup with the page info.
    */
-  public static function getPageInfo($urls = NULL) {
+  public static function getPageInfo(array $urls = NULL) : string {
     if (!$urls) {
       // Default to the current page.
       $urls = [self::getUrl()];

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -102,16 +102,13 @@ class Utility {
    *   The markup with the page info.
    */
   public static function getPageInfo(array $urls = NULL) : string {
+    // Default to the current page.
     if (!$urls) {
-      // Default to the current page.
       $urls = [self::getUrl()];
     }
-    $data = [
-      'Quant-Url' => $urls,
-    ];
 
     $client = \Drupal::service('quant_api.client');
-    $response = $client->getUrlMeta($data);
+    $response = $client->getUrlMeta($urls);
 
     if (isset($response['global_meta']['records'])) {
       // Show meta information for the pages in Quant.

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -2,10 +2,69 @@
 
 namespace Drupal\quant;
 
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\language\Plugin\LanguageNegotiation\LanguageNegotiationUrl;
+use Drupal\quant_api\Client\QuantClientInterface;
+
 /**
  * Quant utility class for helper functions.
  */
 class Utility {
+
+  /**
+   * Determine if URL path prefix language negotiation is being used.
+   */
+  public static function usesLanguagePathPrefixes() {
+    // Only works if there is more than one language.
+    $langcodes = \Drupal::languageManager()->getLanguages();
+    if (count($langcodes) === 1) {
+      return FALSE;
+    }
+
+    $usesPrefixes = FALSE;
+    $languageInterfaceEnabled = \Drupal::config('language.types')->get('negotiation.language_interface.enabled') ?: [];
+    if (isset($languageInterfaceEnabled['language-url'])) {
+      $languageUrl = \Drupal::config('language.negotiation')->get('url');
+      $usesPrefixes = $languageUrl && $languageUrl['source'] === LanguageNegotiationUrl::CONFIG_PATH_PREFIX;
+    }
+    return $usesPrefixes;
+  }
+
+  /**
+   * Get URL based on site settings.
+   *
+   * @return
+   *   The URL adjusted for multilingual settings. Defaults to current url.
+   */
+  public static function getUrl($url = NULL, $langcode = NULL) {
+
+    // Default to current URL.
+    if (!$url) {
+      $url = \Drupal::request()->getRequestUri();
+    }
+
+    // Always start with a slash.
+    if (!str_starts_with($url, '/')) {
+      $url = '/' . $url;
+    }
+
+    // Handle multilingual paths.
+    if (self::usesLanguagePathPrefixes()) {
+      // Use the current language if none is provided.
+      if (!$langcode) {
+        $langcode = \Drupal::languageManager()->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)->getId();
+      }
+      $prefix = '/' . $langcode;
+
+      // Only add the language prefix if it's not there.
+      if (!str_starts_with($url, $prefix)) {
+        $url = $prefix . $url;
+      }
+    }
+
+    return $url;
+  }
 
   /**
    * Checks if it's an external URL.
@@ -24,6 +83,70 @@ class Utility {
       return TRUE;
     }
     return FALSE;
+  }
+
+  /**
+   * Get Quant page info for the given URLs.
+   *
+   * @param array $urls
+   *   The URLs for the page info. Defaults to the current page.
+   *
+   * @return string
+   *   The markup with the page info.
+   */
+  public static function getPageInfo($urls = NULL) {
+    if (!$urls) {
+      // Default to the current page.
+      $urls = [self::getUrl()];
+    }
+    $data = [
+      'Quant-Url' => $urls,
+    ];
+
+    $client = \Drupal::service('quant_api.client');
+    $response = $client->getUrlMeta($data);
+
+    if (isset($response['global_meta']['records'])) {
+      // Show meta information for the pages in Quant.
+      $found_urls = [];
+      $output = '<div class="quant-page-info">';
+      $output .= '<h2>' . t('Quant Page Info') . '</h2>';
+      foreach ($response['global_meta']['records'] as $record) {
+        $found_urls[] = $url = $record['meta']['url'];
+        $output .= '<div class="quant-page-info">';
+        $output .= '<strong>Page info for ' . $url . '</strong>';
+        $output .= '<ul>';
+        $output .= '<li><strong>Published</strong>: ' . ($record['meta']['published'] ? t('Yes') : t('No')) . '</li>';
+        $output .= '<li><strong>Revisions</strong>: ' . $record['meta']['revision_count'] . '</li>';
+        $date = DrupalDateTime::createFromTimestamp($record['meta']['content_timestamp'])->format('Y-m-d H:i:s');
+        $output .= '<li><strong>Updated</strong>: ' . $date . '</li>';
+        $date = DrupalDateTime::createFromTimestamp($record['meta']['date_timestamp'])->format('Y-m-d H:i:s');
+        $output .= '<li><strong>Synced</strong>: ' . $date . '</li>';
+        $output .= '</ul>';
+        $output .= '</div>';
+      }
+
+      // Note any URLs that were not in Quant.
+      if (count($urls) != count($found_urls)) {
+        if (count($urls) === 1) {
+          $output .= '<strong>' . t('Page info could not be found for this URL:') . '</strong>';
+        }
+        else {
+          $output .= '<strong>' . t('Page info could not be found for the following URLs:') . '</strong>';
+        }
+        $output .= '<ul>';
+      }
+      foreach ($urls as $url) {
+        if (!in_array($url, $found_urls)) {
+          $output .= '<li>' . $url . '</li>';
+        }
+        $output .= '</ul>';
+      }
+
+      $output .= '</div>';
+    }
+
+    return $output;
   }
 
 }

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -113,11 +113,11 @@ class Utility {
     if (isset($response['global_meta']['records'])) {
       // Show meta information for the pages in Quant.
       $found_urls = [];
-      $output = '<div class="quant-page-info">';
+      $output = '<div class="quant-page-info messages messages--warning">';
       $output .= '<h2>' . t('Quant Page Info') . '</h2>';
       foreach ($response['global_meta']['records'] as $record) {
         $found_urls[] = $url = $record['meta']['url'];
-        $output .= '<div class="quant-page-info messages messages--warning">';
+        $output .= '<div class="quant-page-info">';
         $output .= '<strong>Page info for ' . $url . '</strong>';
         $output .= '<ul>';
         $output .= '<li><strong>Published</strong>: ' . ($record['meta']['published'] ? t('Yes') : t('No')) . '</li>';


### PR DESCRIPTION
See Drupal.org for details: https://www.drupal.org/project/quantcdn/issues/3405078

**Note that the code from here is also in this PR:**

https://github.com/quantcdn/drupal/pull/202

New setting that will show the page info at the top of the page content. If setting is not enabled, you can still place a block with the same info in any block region. Note that I moved a multilingual helper function to the Utility class.

**New setting**

![Screenshot 2023-11-30 at 7 28 27 PM](https://github.com/quantcdn/drupal/assets/282024/c789ea9c-fd5b-4897-ac91-1984caf9d64a)

**Default location if setting is enabled**

![Screenshot 2023-11-30 at 7 42 05 PM](https://github.com/quantcdn/drupal/assets/282024/94b37b66-f9b7-4814-9c30-3df949bb8b9e)

**Example of placing page info block in the sidebar (setting is disabled)** 

![Screenshot 2023-11-30 at 7 42 26 PM](https://github.com/quantcdn/drupal/assets/282024/fa99a522-aca6-43a1-a1d0-b63ba8303bdb)

**If content is not in Quant, a message will be shown like this**

![Screenshot 2023-11-30 at 7 46 53 PM](https://github.com/quantcdn/drupal/assets/282024/6037ce95-bb27-4914-954d-f1def2bb7d48)
