### PR TITLE
Add path and tag allow lists and messages to Quant purger.

### DIFF
--- a/modules/quant_purger/config/install/quant_purger.settings.yml
+++ b/modules/quant_purger/config/install/quant_purger.settings.yml
@@ -16,3 +16,7 @@ tag_blocklist:
   - 'local_task'
 path_blocklist:
   - '/admin/*'
+tag_allowlist:
+  - ''
+path_allowlist:
+  - ''

--- a/modules/quant_purger/quant_purger.install
+++ b/modules/quant_purger/quant_purger.install
@@ -89,3 +89,13 @@ function quant_purger_update_9101(&$sandbox) {
   $config->set('path_blocklist', ['/admin/*']);
   $config->save();
 }
+
+/**
+ * Update configuration for module settings.
+ */
+function quant_purger_update_9102(&$sandbox) {
+  $config = \Drupal::configFactory()->getEditable('quant_purger.settings');
+  $config->set('tag_allowlist', ['']);
+  $config->set('path_allowlist', ['']);
+  $config->save();
+}

--- a/modules/quant_purger/src/Form/ConfigurationForm.php
+++ b/modules/quant_purger/src/Form/ConfigurationForm.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\quant_purger\Form;
 
-use Drupal\Core\Form\FormStateInterface;
-use Drupal\purge_ui\Form\QueuerConfigFormBase;
 use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Ajax\PrependCommand;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\purge_ui\Form\QueuerConfigFormBase;
 
 /**
  * Configuration form for the Quant queuer.

--- a/modules/quant_purger/src/Form/ConfigurationForm.php
+++ b/modules/quant_purger/src/Form/ConfigurationForm.php
@@ -33,6 +33,11 @@ class ConfigurationForm extends QueuerConfigFormBase {
     $config = $this->config('quant_purger.settings');
     $settings = ['path_blocklist', 'tag_blocklist'];
 
+    $form['info'] = [
+      '#markup' => $this->t('<p class="messages messages--warning">After making changes to the Quant Purger configuration, all content must be re-seeded so the database reflects the changes.<p>'),
+      '#weight' => -10,
+    ];
+
     foreach ($settings as $key) {
       $form["{$key}_fieldset"] = [
         '#type' => 'fieldset',
@@ -139,6 +144,8 @@ class ConfigurationForm extends QueuerConfigFormBase {
       ->set('tag_blocklist', $form_state->getValue('tag_blocklist'))
       ->set('path_blocklist', $form_state->getValue('path_blocklist'))
       ->save();
+
+    \Drupal::messenger()->addMessage($this->t('Succesfully saved the Quant Purger configuration. All content must be re-seeded so the database reflects the changes.'));
   }
 
   /**
@@ -155,7 +162,7 @@ class ConfigurationForm extends QueuerConfigFormBase {
     if (!$form_state->getErrors()) {
       \Drupal::service('quant_purger.registry')->clear();
       $status = 'status';
-      $message = $this->t('Succesfully cleared the traffic registry.');
+      $message = $this->t('Succesfully cleared the traffic registry. All content must be re-seeded so the database reflects the configuration.');
     }
     else {
       $status = 'error';
@@ -171,7 +178,7 @@ class ConfigurationForm extends QueuerConfigFormBase {
    * {@inheritdoc}
    */
   public function validateForm(array &$form, FormStateInterface $form_state) {
-    // @todo Add validation for path_blocklist and tag_blocklist.
+    // @todo Add validation.
   }
 
 }

--- a/modules/quant_purger/src/Form/ConfigurationForm.php
+++ b/modules/quant_purger/src/Form/ConfigurationForm.php
@@ -31,7 +31,12 @@ class ConfigurationForm extends QueuerConfigFormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config('quant_purger.settings');
-    $settings = ['path_blocklist', 'path_allowlist', 'tag_blocklist', 'tag_allowlist'];
+    $settings = [
+      'path_blocklist',
+      'path_allowlist',
+      'tag_blocklist',
+      'tag_allowlist',
+    ];
 
     $form['info'] = [
       '#markup' => $this->t('<p class="messages messages--warning">After making changes to the Quant Purger configuration, all content must be re-seeded so the database reflects the changes.<p>'),
@@ -88,7 +93,7 @@ class ConfigurationForm extends QueuerConfigFormBase {
     $form['path_blocklist_fieldset']['#description'] = $this->t('The Quant purge queuer collects HTTP requests that the Quant module makes to generate static representations of content. It requires that the request has a valid token to limit the performance impact of gathering traffic information in such a manner. This is a user-managed list of paths and query strings that will be excluded from traffic gathering.');
     $form['path_allowlist_fieldset']['#description'] = $this->t('This list overrides paths in the blocklist for more granularly. For example, <code>/admin/*</code> could be in the blocklist and <code>/admin/special/page</code> could be in the allowlist so all admin pages except that one would be excluded.');
     $form['tag_blocklist_fieldset']['#description'] = $this->t('If this list is empty, all cache tag invalidations will trigger a queue entry. Some of these invalidations can have widespread effects on the site and require a full content seed. This setting allows you to exclude certain tags from triggering a content re-seed.');
-    $form['tag_allowlist_fieldset']['#description'] = $this->t('This list overrides tags in the blocklist for more granularly. For example, <code>config:*</code> could be in the blocklist and <code>config:block.block.main_menu</code> could be in the allowlist so all config except that one would be excluded.');
+    $form['tag_allowlist_fieldset']['#description'] = $this->t('This list overrides tags in the blocklist for more granularly. For example, <code>config:*</code> could be in the blocklist and <code>config:system.menu.main</code> could be in the allowlist so all config except that one would be excluded.');
 
     $form['actions']['clear'] = [
       '#type' => 'submit',

--- a/modules/quant_purger/src/Form/ConfigurationForm.php
+++ b/modules/quant_purger/src/Form/ConfigurationForm.php
@@ -31,7 +31,7 @@ class ConfigurationForm extends QueuerConfigFormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config('quant_purger.settings');
-    $settings = ['path_blocklist', 'tag_blocklist'];
+    $settings = ['path_blocklist', 'path_allowlist', 'tag_blocklist', 'tag_allowlist'];
 
     $form['info'] = [
       '#markup' => $this->t('<p class="messages messages--warning">After making changes to the Quant Purger configuration, all content must be re-seeded so the database reflects the changes.<p>'),
@@ -86,8 +86,9 @@ class ConfigurationForm extends QueuerConfigFormBase {
     }
 
     $form['path_blocklist_fieldset']['#description'] = $this->t('The Quant purge queuer collects HTTP requests that the Quant module makes to generate static representations of content. It requires that the request has a valid token to limit the performance impact of gathering traffic information in such a manner. This is a user-managed list of paths and query strings that will be excluded from traffic gathering.');
-
+    $form['path_allowlist_fieldset']['#description'] = $this->t('This list overrides paths in the blocklist for more granularly. For example, <code>/admin/*</code> could be in the blocklist and <code>/admin/special/page</code> could be in the allowlist so all admin pages except that one would be excluded.');
     $form['tag_blocklist_fieldset']['#description'] = $this->t('If this list is empty, all cache tag invalidations will trigger a queue entry. Some of these invalidations can have widespread effects on the site and require a full content seed. This setting allows you to exclude certain tags from triggering a content re-seed.');
+    $form['tag_allowlist_fieldset']['#description'] = $this->t('This list overrides tags in the blocklist for more granularly. For example, <code>config:*</code> could be in the blocklist and <code>config:block.block.main_menu</code> could be in the allowlist so all config except that one would be excluded.');
 
     $form['actions']['clear'] = [
       '#type' => 'submit',
@@ -142,7 +143,9 @@ class ConfigurationForm extends QueuerConfigFormBase {
   public function submitFormSuccess(array &$form, FormStateInterface $form_state) {
     $this->config('quant_purger.settings')
       ->set('tag_blocklist', $form_state->getValue('tag_blocklist'))
+      ->set('tag_allowlist', $form_state->getValue('tag_allowlist'))
       ->set('path_blocklist', $form_state->getValue('path_blocklist'))
+      ->set('path_allowlist', $form_state->getValue('path_allowlist'))
       ->save();
 
     \Drupal::messenger()->addMessage($this->t('Succesfully saved the Quant Purger configuration. All content must be re-seeded so the database reflects the changes.'));

--- a/modules/quant_purger/src/StackMiddleware/TraitUrlRegistrar.php
+++ b/modules/quant_purger/src/StackMiddleware/TraitUrlRegistrar.php
@@ -2,9 +2,10 @@
 
 namespace Drupal\quant_purger\StackMiddleware;
 
+use Drupal\Core\Cache\CacheableResponseInterface;
+use Drupal\quant\Utility;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Drupal\Core\Cache\CacheableResponseInterface;
 
 /**
  * Methods for the URL registrar classes.
@@ -76,16 +77,22 @@ trait TraitUrlRegistrar {
    */
   protected function getAcceptedCacheTags(array $tag_list) {
     // Remove tags from blocklist.
+    $tags1 = [];
     $blocklist = $this->config->get('tag_blocklist');
     $blocklist = is_array($blocklist) ? array_filter($blocklist) : [];
-    $tags1 = preg_grep('/^(' . implode('|', $blocklist) . ')/', $tag_list, PREG_GREP_INVERT);
+    if (!empty($blocklist)) {
+      $tags1 = preg_grep('/^(' . implode('|', $blocklist) . ')/', $tag_list, PREG_GREP_INVERT);
+    }
 
-    // Add tags from allowlist.
+    // Add tags from allowlist. This must be done after the blocklist.
+    $tags2 = [];
     $allowlist = $this->config->get('tag_allowlist');
     $allowlist = is_array($allowlist) ? array_filter($allowlist) : [];
-    $tags2 = preg_grep('/^(' . implode('|', $allowlist) . ')/', $tag_list);
+    if (!empty($allowlist)) {
+      $tags2 = preg_grep('/^(' . implode('|', $allowlist) . ')/', $tag_list);
+    }
 
-    $tags = array_merge($tags1, $tags2);
+    $tags = array_unique(array_merge($tags1, $tags2));
 
     return array_filter($tags);
   }

--- a/modules/quant_purger/src/TrafficRegistry.php
+++ b/modules/quant_purger/src/TrafficRegistry.php
@@ -42,7 +42,7 @@ class TrafficRegistry implements TrafficRegistryInterface {
    * {@inheritdoc}
    */
   public function add($url, array $tags) {
-    $tags = ';' . implode(';', $tags);
+    $tags = ';' . implode(';', $tags) . ';';
     $fields = ['url' => $url, 'tags' => $tags];
 
     $this->connection->merge('purge_queuer_quant')

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -39,14 +39,12 @@ class Utility {
    */
   public static function inList($item, array $list) {
     $found = FALSE;
-    if (is_array($list)) {
-      foreach (array_filter($list) as $needle) {
-        $pattern = preg_quote($needle, '/');
-        $pattern = str_replace('\*', '.*', $pattern);
-        preg_match('/^(' . $pattern . ')/', $item, $is_match);
-        if (!empty($is_match)) {
-          $found = TRUE;
-        }
+    foreach (array_filter($list) as $needle) {
+      $pattern = preg_quote($needle, '/');
+      $pattern = str_replace('\*', '.*', $pattern);
+      preg_match('/^(' . $pattern . ')/', $item, $is_match);
+      if (!empty($is_match)) {
+        $found = TRUE;
       }
     }
 

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -26,4 +26,31 @@ class Utility {
     return FALSE;
   }
 
+  /**
+   * Checks if an item is in a list which may use regular expressions.
+   *
+   * @param string $item
+   *   The item to check for.
+   * @param array $list
+   *   The list to check. Items in the list can use regex.
+   *
+   * @return bool
+   *   TRUE if the item is in the list and FALSE otherwise.
+   */
+  public static function inList($item, $list) {
+    $found = FALSE;
+    if (is_array($list)) {
+      foreach (array_filter($list) as $needle) {
+        $pattern = preg_quote($needle, '/');
+        $pattern = str_replace('\*', '.*', $pattern);
+        preg_match('/^(' . $pattern . ')/', $item, $is_match);
+        if (!empty($is_match)) {
+          $found = TRUE;
+        }
+      }
+    }
+
+    return $found;
+  }
+
 }

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -37,7 +37,7 @@ class Utility {
    * @return bool
    *   TRUE if the item is in the list and FALSE otherwise.
    */
-  public static function inList($item, $list) {
+  public static function inList($item, array $list) {
     $found = FALSE;
     if (is_array($list)) {
       foreach (array_filter($list) as $needle) {

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -117,7 +117,7 @@ class Utility {
     return $found;
   }
 
-  /*
+  /**
    * Get Quant page info for the given URLs.
    *
    * @param array $urls


### PR DESCRIPTION
See details in Drupal.org issues:

https://www.drupal.org/project/quantcdn/issues/3412162
https://www.drupal.org/project/quantcdn/issues/3412158
https://www.drupal.org/project/quantcdn/issues/3412205

1. Fixed delimiter issue that prevented the last cache tag from working.
2. Added some messages for the config form for better DX/UX.
3. Added path and tag allow lists that override any blocklist items.

**For 1, the tags now look like below with a semicolon at the end:**

```
;block_content:2;block_content:1;taxonomy_term:33;media:19;file:38;taxonomy_term:16;taxonomy_term:15;taxonomy_term:14;taxonomy_term:13;taxonomy_term:12;taxonomy_term:11;taxonomy_term:10;taxonomy_term:9;taxonomy_term:8;taxonomy_term:7;taxonomy_term:6;taxonomy_term:5;taxonomy_term:4;taxonomy_term:3;taxonomy_term:2;taxonomy_term:1;node:4;media:4;taxonomy_term_view;node:9;node:2;config:system.menu.main;  
```

**2. Messages look like:**

![Screenshot 2024-01-03 at 5 15 27 PM](https://github.com/quantcdn/drupal/assets/282024/b3b99464-8210-4e51-8fec-c4006fc93b9e)

![Screenshot 2024-01-03 at 5 15 45 PM](https://github.com/quantcdn/drupal/assets/282024/136efa7b-8221-4767-8f0a-2ecbcf71e9f6)

**3. New form fields look like below:**

Both path and tag allow lists were tested. The Drupal.org issue explains how to test the tags. For the path allow list, I added something to the block list where there were many similar pages and then in the allow list, added a pattern so that some of the pages still were allowed.
 
![Screenshot 2024-01-03 at 5 11 53 PM](https://github.com/quantcdn/drupal/assets/282024/66a63c4a-a7c3-48c4-bb43-9ef1b301edfe)

![Screenshot 2024-01-03 at 5 12 03 PM](https://github.com/quantcdn/drupal/assets/282024/473fce1f-3acd-4596-bb49-51265c7994ae)
