### PR TITLE
Updated logic to handle multilingual internal path redirects.

### DIFF
--- a/modules/quant_search/src/Controller/Search.php
+++ b/modules/quant_search/src/Controller/Search.php
@@ -8,6 +8,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use Drupal\node\Entity\Node;
 use Drupal\quant\Seed;
+use Drupal\quant\Utility;
 use Drupal\quant_api\Client\QuantClientInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -248,10 +249,8 @@ class Search extends ControllerBase {
       $record['image'] = Seed::rewriteRelative($record['image']);
     }
 
-    $options = ['absolute' => FALSE];
     if (!empty($langcode)) {
       $language = \Drupal::languageManager()->getLanguage($langcode);
-      $options['language'] = $language;
       $record['lang_code'] = $langcode;
 
       foreach ($entity->getTranslationLanguages() as $code => $lang) {
@@ -261,8 +260,8 @@ class Search extends ControllerBase {
     }
 
     // @todo Update node-only logic.
-    // The "canonical" URL is the alias, if it exists, or the internal path.
-    $record['url'] = Url::fromRoute('entity.node.canonical', ['node' => $entity->id()], $options)->toString();
+    $record['url'] = Utility::getCanonicalUrl('node', $entity->id(), $langcode);
+
 
     // Add search meta for node entities.
     if ($entity->getEntityTypeId() == 'node') {

--- a/modules/quant_search/src/Controller/Search.php
+++ b/modules/quant_search/src/Controller/Search.php
@@ -261,6 +261,7 @@ class Search extends ControllerBase {
     }
 
     // @todo Update node-only logic.
+    // The "canonical" URL is the alias, if it exists, or the internal path.
     $record['url'] = Url::fromRoute('entity.node.canonical', ['node' => $entity->id()], $options)->toString();
 
     // Add search meta for node entities.

--- a/modules/quant_search/src/Controller/Search.php
+++ b/modules/quant_search/src/Controller/Search.php
@@ -5,7 +5,6 @@ namespace Drupal\quant_search\Controller;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\Core\Url;
 use Drupal\node\Entity\Node;
 use Drupal\quant\Seed;
 use Drupal\quant\Utility;
@@ -261,7 +260,6 @@ class Search extends ControllerBase {
 
     // @todo Update node-only logic.
     $record['url'] = Utility::getCanonicalUrl('node', $entity->id(), $langcode);
-
 
     // Add search meta for node entities.
     if ($entity->getEntityTypeId() == 'node') {

--- a/quant.module
+++ b/quant.module
@@ -191,6 +191,7 @@ function quant_node_access(NodeInterface $node, $op, AccountInterface $account) 
     return AccessResult::neutral();
   }
 
+  // The "canonical" URL is the alias, if it exists, or the internal path.
   $options = ['absolute' => FALSE];
   $url = Url::fromRoute('entity.node.canonical', ['node' => $node->id()], $options)->toString();
 

--- a/quant.module
+++ b/quant.module
@@ -192,6 +192,7 @@ function quant_node_access(NodeInterface $node, $op, AccountInterface $account) 
   }
 
   // The "canonical" URL is the alias, if it exists, or the internal path.
+  // @todo Use Utility::getCanonicalUrl()?
   $options = ['absolute' => FALSE];
   $url = Url::fromRoute('entity.node.canonical', ['node' => $node->id()], $options)->toString();
 

--- a/quant.module
+++ b/quant.module
@@ -412,6 +412,10 @@ function quant_modules_uninstalled($modules) {
  *   The path alias.
  */
 function quant_path_alias_presave(EntityInterface $pathAlias) {
+  if (!$pathAlias || !$pathAlias->original) {
+    return;
+  }
+
   // Original path alias.
   $original_path = $pathAlias->original->get('path')->value;
   $original_alias = $pathAlias->original->get('alias')->value;

--- a/src/Seed.php
+++ b/src/Seed.php
@@ -265,6 +265,7 @@ class Seed {
     $rid = $entity->get('vid')->value;
 
     $url = Utility::getCanonicalUrl('node', $nid, $langcode);
+    $defaultLangcode = \Drupal::languageManager()->getDefaultLanguage()->getId();
 
     // If this is the front/home page, rewrite URL as /.
     $site_config = \Drupal::config('system.site');

--- a/src/Seed.php
+++ b/src/Seed.php
@@ -402,6 +402,15 @@ class Seed {
   /**
    * Handle canonical redirects.
    *
+   * Example redirects:
+   * - en node 123, no alias: /node/123 to /en/node/123.
+   * - es node 123, no alias: /node/123 to /es/node/123.
+   * - en node 123, alias: /node/123 and /en/node/123 to en alias.
+   * - es node 123, alias: /node/123 and /es/node/123 to es alias.
+   * - en node 123, es translation, no alias: /node/123 to /en/node/123.
+   * - en node 123, es translation, alias: /node/123 and /en/node/123 to en
+   *   alias, /es/node/123 to es alias.
+   *
    * @todo Create simpler logic for when multilingual isn't used?
    */
   public static function handleCanonicalRedirects($entity, $langcode, $url) {

--- a/src/Seed.php
+++ b/src/Seed.php
@@ -8,7 +8,6 @@ use Drupal\Core\Url;
 use Drupal\node\Entity\Node;
 use Drupal\quant\Event\QuantEvent;
 use Drupal\quant\Event\QuantRedirectEvent;
-use Drupal\quant\Utility;
 use Drupal\taxonomy\Entity\Term;
 use GuzzleHttp\Exception\ConnectException;
 

--- a/src/Seed.php
+++ b/src/Seed.php
@@ -6,9 +6,10 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Url;
 use Drupal\node\Entity\Node;
-use Drupal\taxonomy\Entity\Term;
 use Drupal\quant\Event\QuantEvent;
 use Drupal\quant\Event\QuantRedirectEvent;
+use Drupal\quant\Utility;
+use Drupal\taxonomy\Entity\Term;
 use GuzzleHttp\Exception\ConnectException;
 
 /**
@@ -212,14 +213,7 @@ class Seed {
   public static function seedTaxonomyTerm($entity, $langcode = NULL) {
     $tid = $entity->get('tid')->value;
 
-    $options = ['absolute' => FALSE];
-    if (!empty($langcode)) {
-      $language = \Drupal::languageManager()->getLanguage($langcode);
-      $options['language'] = $language;
-    }
-
-    // The "canonical" URL is the alias, if it exists, or the internal path.
-    $url = Url::fromRoute('entity.taxonomy_term.canonical', ['taxonomy_term' => $tid], $options)->toString();
+    $url = Utility::getCanonicalUrl('taxonomy_term', $tid, $langcode);
     $response = self::markupFromRoute($url);
 
     if (empty($response)) {
@@ -271,14 +265,7 @@ class Seed {
     $nid = $entity->get('nid')->value;
     $rid = $entity->get('vid')->value;
 
-    $options = ['absolute' => FALSE];
-    if (!empty($langcode)) {
-      $language = \Drupal::languageManager()->getLanguage($langcode);
-      $options['language'] = $language;
-    }
-
-    // The "canonical" URL is the alias, if it exists, or the internal path.
-    $url = Url::fromRoute('entity.node.canonical', ['node' => $nid], $options)->toString();
+    $url = Utility::getCanonicalUrl('node', $nid, $langcode);
 
     // Special case for home-page, rewrite URL as /.
     $site_config = \Drupal::config('system.site');
@@ -350,14 +337,7 @@ class Seed {
     $langcode = $entity->language()->getId();
     $nid = $entity->get('nid')->value;
 
-    $options = ['absolute' => FALSE];
-    if (!empty($langcode)) {
-      $language = \Drupal::languageManager()->getLanguage($langcode);
-      $options['language'] = $language;
-    }
-
-    // The "canonical" URL is the alias, if it exists, or the internal path.
-    $url = Url::fromRoute('entity.node.canonical', ['node' => $nid], $options)->toString();
+    $url = Utility::getCanonicalUrl('node', $nid, $langcode);
 
     $site_config = \Drupal::config('system.site');
     $front = $site_config->get('page.front');
@@ -382,14 +362,7 @@ class Seed {
     $langcode = $entity->language()->getId();
     $tid = $entity->get('tid')->value;
 
-    $options = ['absolute' => FALSE];
-    if (!empty($langcode)) {
-      $language = \Drupal::languageManager()->getLanguage($langcode);
-      $options['language'] = $language;
-    }
-
-    // The "canonical" URL is the alias, if it exists, or the internal path.
-    $url = Url::fromRoute('entity.taxonomy_term.canonical', ['taxonomy_term' => $tid], $options)->toString();
+    $url = Utility::getCanonicalUrl('taxonomy_term', $tid, $langcode);
 
     // Handle internal path redirects.
     self::handleInternalPathRedirects($entity, $langcode, $url);

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -79,7 +79,7 @@ class Utility {
    *
    * @param string $type
    *   The entity type.
-   * @param integer $id
+   * @param int $id
    *   The entity id.
    * @param string $langcode
    *   The language code.

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -4,6 +4,7 @@ namespace Drupal\quant;
 
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Url;
 use Drupal\language\Plugin\LanguageNegotiation\LanguageNegotiationUrl;
 
 /**
@@ -71,6 +72,30 @@ class Utility {
     }
 
     return $url;
+  }
+
+  /**
+   * Get the canonical URL.
+   *
+   * @param string $type
+   *   The entity type.
+   * @param integer $id
+   *   The entity id.
+   * @param string $langcode
+   *   The language code.
+   *
+   * @return string
+   *   The relative canonical URL.
+   */
+  public static function getCanonicalUrl($type, $id, $langcode) {
+    $options = ['absolute' => FALSE];
+    if (!empty($langcode)) {
+      $language = \Drupal::languageManager()->getLanguage($langcode);
+      $options['language'] = $language;
+    }
+
+    // The "canonical" URL is the alias, if it exists, or the internal path.
+    return Url::fromRoute('entity.' . $type . '.canonical', [$type => $id], $options)->toString();
   }
 
   /**

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -158,10 +158,10 @@ class Utility {
       // Note any URLs that were not in Quant.
       if (count($urls) != count($found_urls)) {
         if (count($urls) === 1) {
-          $output .= '<strong>' . t('Page info could not be found for this URL:') . '</strong>';
+          $output .= '<strong>' . t('Page info could not be found for this URL. If this content has been synced, try clearing the cache.') . '</strong>';
         }
         else {
-          $output .= '<strong>' . t('Page info could not be found for the following URLs:') . '</strong>';
+          $output .= '<strong>' . t('Page info could not be found for the following URLs. If this content has been synced, try clearing the cache.') . '</strong>';
         }
         $output .= '<ul>';
       }


### PR DESCRIPTION
See details in these Drupal.org issues:

https://www.drupal.org/project/quantcdn/issues/3343237
https://www.drupal.org/project/quantcdn/issues/3413036
https://www.drupal.org/project/quantcdn/issues/3343245

Tested thoroughly with nodes/terms:

1. Node - English only, alias and no alias, published and unpublished, including content type with translation disabled
2. Node - Spanish only, alias and no alias, published and unpublished
3. Node - English and Spanish, same/different aliases and no alias, published and unpublished
4. Term - English only, alias and no alias, published and unpublished
5. Term - Spanish only, alias and no alias, published and unpublished
6. Term - English and Spanish, same/different aliases and no alias, published and unpublished

The only thing I noticed is that content is not created if it's unpublished to start with (though the canonical redirects are created). This is a separate issue that isn't very pressing.

See my chicken scratches and the comments below for all the permutations tested:

![quant-multingual-redirects-node-testing](https://github.com/quantcdn/drupal/assets/282024/7fb02f13-ce35-486a-a51c-60ed43e9faf5)

![quant-multingual-redirects-term-testing](https://github.com/quantcdn/drupal/assets/282024/44a5b657-92fe-422b-b057-d3be8444e962)
