### PR TITLE
Added access check for page info.

### DIFF
--- a/src/Utility.php
+++ b/src/Utility.php
@@ -128,6 +128,12 @@ class Utility {
    */
   public static function getPageInfo(array $urls = NULL) : string {
     try {
+      // Only allow administrators and content editors access.
+      $roles = ['administrator', 'content_editor', 'editor'];
+      if (empty(array_intersect($roles, \Drupal::currentUser()->getRoles()))) {
+        return '';
+      }
+
       // Default to the current page.
       if (!$urls) {
         $urls = [self::getUrl()];


### PR DESCRIPTION
See details in Drupal.org issue:

https://www.drupal.org/project/quantcdn/issues/3416086

Checking roles rather than adding a new permission for simplicity.