### PR TITLE
Updated special pages logic to avoid errors.

### DIFF
--- a/quant.module
+++ b/quant.module
@@ -358,19 +358,11 @@ function quant_form_system_site_information_settings_alter(&$form, FormStateInte
  * Update the special pages when the form is saved.
  */
 function quant_special_pages() {
-  $system = \Drupal::config('system.site');
-  $system_pages = [
-    $system->get('page.front'),
-    $system->get('page.404'),
-    $system->get('page.403'),
-    '/',
-    '/_quant404',
-    '/_quant403',
-  ];
 
-  foreach ($system_pages as $route) {
+  foreach (Utility::getSpecialPages() as $route) {
     $item = new RouteItem(['route' => $route]);
     $item->send();
+    \Drupal::logger('quant')->notice("Sending route: @route", ['@route' => $route]);
   }
 }
 

--- a/src/EventSubscriber/CollectionSubscriber.php
+++ b/src/EventSubscriber/CollectionSubscriber.php
@@ -8,6 +8,7 @@ use Drupal\quant\Event\CollectRedirectsEvent;
 use Drupal\quant\Event\CollectRoutesEvent;
 use Drupal\quant\Event\CollectTaxonomyTermsEvent;
 use Drupal\quant\Event\QuantCollectionEvents;
+use Drupal\quant\Utility;
 use Drupal\user\Entity\User;
 use Drupal\views\Views;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -239,21 +240,8 @@ class CollectionSubscriber implements EventSubscriberInterface {
     // Handle unpublished content based on settings.
     $disable_drafts = $this->configFactory->get('quant.settings')->get('disable_content_drafts');
 
-    // Collect the site configured routes.
-    $system = $this->configFactory->get('system.site');
-    $system_pages = ['page.front', 'page.404', 'page.403'];
-
-    foreach ($system_pages as $config) {
-      $system_path = $system->get($config);
-      if (!empty($system_path)) {
-        $event->queueItem(['route' => $system_path]);
-      }
-    }
-
     // Add special Quant pages.
-    $quant_pages = ['/', '/_quant404', '/_quant403'];
-
-    foreach ($quant_pages as $page) {
+    foreach (Utility::getSpecialPages() as $page) {
       $event->queueItem(['route' => $page]);
     }
 

--- a/src/Seed.php
+++ b/src/Seed.php
@@ -286,13 +286,14 @@ class Seed {
 
     $url = Url::fromRoute('entity.node.canonical', ['node' => $nid], $options)->toString();
 
-    // Special case for home-page, rewrite URL as /.
+    // If this is the front/home page, rewrite URL as /.
+    // @todo Handle translated front/home page.
     $site_config = \Drupal::config('system.site');
     $front = $site_config->get('page.front');
 
     if ((strpos($front, '/node/') === 0) && $nid == substr($front, 6)) {
       if ($entity->isPublished() && $entity->isDefaultRevision()) {
-        // Trigger redirect event from alias to home.
+        // Trigger redirect event from alias to /.
         \Drupal::service('event_dispatcher')->dispatch(new QuantRedirectEvent($url, "/", 301), QuantRedirectEvent::UPDATE);
       }
       $url = "/";
@@ -319,16 +320,27 @@ class Seed {
       }
     }
 
-    // Special case pages (403/404/Home)
-    $specialPages = [
-      '/' => $site_config->get('page.front'),
-      '/_quant404' => $site_config->get('page.404'),
+    // Handle status pages. Must happen after response has been checked.
+    $statusPages = [
       '/_quant403' => $site_config->get('page.403'),
+      '/_quant404' => $site_config->get('page.404'),
     ];
 
-    foreach ($specialPages as $k => $v) {
-      if ((strpos($v, '/node/') === 0) && $entity->get('nid')->value == substr($v, 6)) {
-        $url = $k;
+    // If this node is a status page, rewrite URL to use special internal route
+    // so they show up properly when getting a 403 or 404 status code.
+    foreach ($statusPages as $key => $value) {
+      if ((strpos($value, '/node/') === 0) && $entity->get('nid')->value == substr($value, 6)) {
+        // Only set for the default language.
+        // @todo Handle translated status pages.
+        if (empty($langcode) || $langcode == \Drupal::languageManager()->getDefaultLanguage()->getId()) {
+          $url = $key;
+          \Drupal::logger('quant')->notice("Setting status page: @key => @value",
+            [
+              '@key' => $key,
+              '@value' => $value,
+            ]
+          );
+        }
       }
     }
 

--- a/src/Seed.php
+++ b/src/Seed.php
@@ -300,7 +300,7 @@ class Seed {
       $url = "/";
 
       // Handle default language prefix.
-      if ($langcode && $langcode == $defaultLangcode) {
+      if ($langcode == $defaultLangcode) {
         // Tack on the prefix if it's set.
         $negotiation = \Drupal::config('language.negotiation')->get('url');
         $url .= $negotiation['prefixes'][$langcode] ?? '';

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -57,20 +57,41 @@ class Utility {
     }
 
     // Handle multilingual paths.
+    $prefix = self::getPathPrefix($langcode);
+
+    // Only add the language prefix if it's not there.
+    if (!str_starts_with($url, $prefix)) {
+      $url = $prefix . $url;
+    }
+
+    return $url;
+  }
+
+  /**
+   * Get path prefix based on site settings.
+   *
+   * @param string $langcode
+   *   The language code.
+   *
+   * @return string
+   *   The path prefix based on multilingual settings. Defaults to '/'.
+   */
+  public static function getPathPrefix(string $langcode = NULL) : string {
+
+    // Always start with a slash.
+    $prefix = '/';
+
+    // Handle multilingual paths.
     if (self::usesLanguagePathPrefixes()) {
       // Use the current language if none is provided.
       if (!$langcode) {
         $langcode = \Drupal::languageManager()->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)->getId();
       }
+      // @todo Handle when prefix is different than the langcode.
       $prefix = '/' . $langcode;
-
-      // Only add the language prefix if it's not there.
-      if (!str_starts_with($url, $prefix)) {
-        $url = $prefix . $url;
-      }
     }
 
-    return $url;
+    return $prefix;
   }
 
   /**

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -118,6 +118,34 @@ class Utility {
   }
 
   /**
+   * Get special pages.
+   *
+   * @return array
+   *   An array of special pages to process.
+   */
+  public static function getSpecialPages() {
+    $system = \Drupal::config('system.site');
+    $pages = [
+      $system->get('page.front'),
+      $system->get('page.404'),
+      $system->get('page.403'),
+      '/',
+      '/_quant404',
+      '/_quant403',
+    ];
+
+    $validator = \Drupal::service('path.validator');
+    foreach ($pages as $index => $page) {
+      // Remove any pages that don't exist.
+      if (empty($page) || !$validator->getUrlIfValid($page)) {
+        unset($pages[$index]);
+      }
+    }
+
+    return $pages;
+  }
+
+  /**
    * Get Quant page info for the given URLs.
    *
    * @param array $urls


### PR DESCRIPTION
See details in Drupal.org issues:

https://www.drupal.org/project/quantcdn/issues/3399286
https://www.drupal.org/project/quantcdn/issues/3418169

Example logging when 403 and 404 are set in config and there's a Spanish home page:

 **with /en prefix set**
```
 [notice] [node_item] - node_id: 1 vid: 2
 [notice] [node_item] - node_id: 2 vid: 4
 [notice] [node_item] - node_id: 3 vid: 6
 [notice] Setting status page: /_quant404 => /node/3
 [notice] Setting status page: /_quant403 => /node/2
 [notice] [node_item] - node_id: 4 vid: 8
 [notice] [node_item] - node_id: 5 vid: 10
 [notice] Adding home page redirect: / => /en
 [notice] Adding translated home page: /es
 [notice] [node_item] - node_id: 7 vid: 14
```

 **without /en prefix set**
```
 [notice] [node_item] - node_id: 1 vid: 2
 [notice] [node_item] - node_id: 2 vid: 4
 [notice] [node_item] - node_id: 3 vid: 6
 [notice] Setting status page: /_quant403 => /node/2
 [notice] Setting status page: /_quant404 => /node/3
 [notice] [node_item] - node_id: 4 vid: 8
 [notice] [node_item] - node_id: 5 vid: 10
 [notice] Adding translated home page: /es
 [notice] [node_item] - node_id: 7 vid: 14
```
