### PR TITLE
Added check for empty language prefix.

### DIFF
--- a/src/EventSubscriber/CollectionSubscriber.php
+++ b/src/EventSubscriber/CollectionSubscriber.php
@@ -310,10 +310,12 @@ class CollectionSubscriber implements EventSubscriberInterface {
             $base = \Drupal::request()->getBaseUrl();
             $event->queueItem(['route' => $base . "/{$path}"]);
 
-            // Languge negotiation may also provide path prefixes.
+            // Language negotiation may also provide path prefixes.
             if ($prefixes = \Drupal::config('language.negotiation')->get('url.prefixes')) {
               foreach ($prefixes as $prefix) {
-                $event->queueItem(['route' => "/{$prefix}/{$path}"]);
+                if ($prefix) {
+                  $event->queueItem(['route' => "/{$prefix}/{$path}"]);
+                }
               }
             }
           }


### PR DESCRIPTION
See details in Drupal.org issue:

https://www.drupal.org/project/quantcdn/issues/3418192

Before
```
 [notice] [route_item] /articles
 [notice] [route_item] //articles
 [notice] [route_item] /es/articles
 [notice] [route_item] //node
 [notice] [route_item] /es/node
 [notice] [route_item] /recipes
 [notice] [route_item] //recipes
 [notice] [route_item] /es/recipes
```

After
```
 [notice] [route_item] /articles
 [notice] [route_item] /es/articles
 [notice] [route_item] /node
 [notice] [route_item] /es/node
 [notice] [route_item] /recipes
 [notice] [route_item] /es/recipes
```

and if you add the prefix back in:

```
 [notice] [route_item] /articles
 [notice] [route_item] /en/articles
 [notice] [route_item] /es/articles
 [notice] [route_item] /node
 [notice] [route_item] /en/node
 [notice] [route_item] /es/node
 [notice] [route_item] /recipes
 [notice] [route_item] /en/recipes
 [notice] [route_item] /es/recipes
```