### PR TITLE
Updated Simple Sitemap logic to avoid errors.

### DIFF
--- a/modules/quant_sitemap/src/EventSubscriber/CollectionSubscriber.php
+++ b/modules/quant_sitemap/src/EventSubscriber/CollectionSubscriber.php
@@ -50,6 +50,7 @@ class CollectionSubscriber implements EventSubscriberInterface {
     }
     foreach ($this->manager->getSitemaps() as $route) {
       $event->queueItem(['route' => $route]);
+      \Drupal::logger('quant_sitemap')->notice("[route_item] @route", ['@route' => $route]);
     }
   }
 

--- a/modules/quant_sitemap/src/EventSubscriber/CollectionSubscriber.php
+++ b/modules/quant_sitemap/src/EventSubscriber/CollectionSubscriber.php
@@ -50,7 +50,6 @@ class CollectionSubscriber implements EventSubscriberInterface {
     }
     foreach ($this->manager->getSitemaps() as $route) {
       $event->queueItem(['route' => $route]);
-      \Drupal::logger('quant_sitemap')->notice("[route_item] @route", ['@route' => $route]);
     }
   }
 

--- a/modules/quant_sitemap/src/SitemapManager.php
+++ b/modules/quant_sitemap/src/SitemapManager.php
@@ -6,7 +6,6 @@ use Drupal\Core\Extension\ModuleHandler;
 use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\Extension\ModuleExtensionList;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
-use Drupal\Core\Url;
 
 /**
  * Sitemap manager for Quant Sitemap.

--- a/src/Commands/QuantDrushCommands.php
+++ b/src/Commands/QuantDrushCommands.php
@@ -180,6 +180,7 @@ class QuantDrushCommands extends DrushCommands {
       'file_paths',
       'file_paths_textarea',
       'robots',
+      'export_sitemap',
       'lunr',
     ];
 


### PR DESCRIPTION
See details in Drupal.org issue:

https://www.drupal.org/project/quantcdn/issues/3388797
https://www.drupal.org/project/quantcdn/issues/3418240

Added another sitemap with the default xsl generator and it looks like this:

```
kristens-mbp:quantcdn kristenpol$ qrunq
Forking seed worker.
Using drush binary at /var/www/html/vendor/bin/drush. Override with $DRUSH_PATH if required.
 [notice] [route_item] /node/1
 [notice] [route_item] /node/3
 [notice] [route_item] /node/2
 [notice] [route_item] /
 [notice] [route_item] /sitemaps/whatever/sitemap.xml
 [notice] [route_item] /sitemap_generator/default/sitemap.xsl
 [notice] [route_item] /sitemap.xml
 [success] Processed 1 items from the quant_seed_worker queue in 2.42 sec.
 [success] Processed 1 items from the quant_seed_worker queue in 2.73 sec.
 [success] Processed 2 items from the quant_seed_worker queue in 2.85 sec.
 [success] Processed 1 items from the quant_seed_worker queue in 3.2 sec.
 [success] Processed 2 items from the quant_seed_worker queue in 3.67 sec.
Seeding complete.
```