### PR TITLE
Rewrite iframe URLs so they always work.

### DIFF
--- a/modules/quant_api/src/EventSubscriber/QuantApi.php
+++ b/modules/quant_api/src/EventSubscriber/QuantApi.php
@@ -263,8 +263,13 @@ class QuantApi implements EventSubscriberInterface {
     /** @var \DOMElement $node */
     foreach ($xpath->query('//iframe[contains(@src, "/media/oembed")]') as $node) {
       $oembed_url = $new_href = $node->getAttribute('src');
-      $oembed_item = new RouteItem(['route' => $oembed_url]);
-      $oembed_item->send();
+      // Only add if it's a relative URL to handle the case where the URL
+      // contains `/media/oembed` but is from another website.
+      if (str_starts_with($oembed_url, '/')) {
+        $oembed_item = new RouteItem(['route' => $oembed_url]);
+        $oembed_item->send();
+        $this->logger->notice("[route_item] $oembed_url");
+      }
     }
 
     // @todo Report on forms that need proxying (attachments.forms).

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -108,7 +108,7 @@ class Utility {
    * @return string
    *   The relative canonical URL.
    */
-  public static function getCanonicalUrl($type, $id, $langcode) {
+  public static function getCanonicalUrl(string $type, int $id, string $langcode) : string {
     $options = ['absolute' => FALSE];
     if (!empty($langcode)) {
       $language = \Drupal::languageManager()->getLanguage($langcode);
@@ -117,6 +117,28 @@ class Utility {
 
     // The "canonical" URL is the alias, if it exists, or the internal path.
     return Url::fromRoute('entity.' . $type . '.canonical', [$type => $id], $options)->toString();
+  }
+
+  /**
+   * Strip local host from text.
+   *
+   * @param string $text
+   *   The text.
+   *
+   * @return string
+   *   The text without local host.
+   */
+  public static function stripLocalHost(string $text) : string {
+
+    $config = \Drupal::config('quant.settings');
+    $hostname = $config->get('host_domain') ?: $_SERVER['SERVER_NAME'];
+    $port = $_SERVER['SERVER_PORT'];
+    $text = preg_replace("/(https?:\/\/)?{$hostname}(\:{$port})?/i", '', $text);
+
+    // Edge case: Replace http://default when run via drush without base_url.
+    $text = preg_replace("/http:\/\/default/i", '', $text);
+
+    return $text;
   }
 
   /**


### PR DESCRIPTION
See details in Drupal.org issue:

https://www.drupal.org/project/quantcdn/issues/3425798

When testing different iframe URLs within the body text, it strips the local website host (`https://quantdrupal101.ddev.site` for me) but not `http[s]://localhost` but maybe that's okay because it's using the existing strip logic (so will be same for everything)?

```
Direct link

<iframe src="https://youtu.be/S6E5miZSnBg?feature=shared"></iframe>

Embed link relative

<iframe src="/en/media/oembed?url=https%3A//www.youtube.com/watch%3Fv%3DS6E5miZSnBg&amp;max_width=0&amp;max_height=0&amp;hash=ohdyEQYjYvB1YXptQAJiWkDEB5UOLFQZA1l_Q-m6DHc"></iframe>

Embed link localhost https

<iframe src="https://localhost//en/media/oembed?url=https%3A//www.youtube.com/watch%3Fv%3DS6E5miZSnBg&amp;max_width=0&amp;max_height=0&amp;hash=ohdyEQYjYvB1YXptQAJiWkDEB5UOLFQZA1l_Q-m6DHc"></iframe>

Embed link localhost http

<iframe src="http://localhost/en/media/oembed?url=https%3A//www.youtube.com/watch%3Fv%3DS6E5miZSnBg&amp;max_width=0&amp;max_height=0&amp;hash=ohdyEQYjYvB1YXptQAJiWkDEB5UOLFQZA1l_Q-m6DHc"></iframe>

Embed link ddev host https

<iframe src="/en/media/oembed?url=https%3A//www.youtube.com/watch%3Fv%3DS6E5miZSnBg&amp;max_width=0&amp;max_height=0&amp;hash=ohdyEQYjYvB1YXptQAJiWkDEB5UOLFQZA1l_Q-m6DHc"></iframe>

Embed link ddev host http

<iframe src="/en/media/oembed?url=https%3A//www.youtube.com/watch%3Fv%3DS6E5miZSnBg&amp;max_width=0&amp;max_height=0&amp;hash=ohdyEQYjYvB1YXptQAJiWkDEB5UOLFQZA1l_Q-m6DHc"></iframe>

```

