### PR TITLE
Show warning if view has exposed filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         ports:
           - 3306:3306
         env:
-          MYSQL_DATABASE: drupal11
+          MYSQL_DATABASE: drupal
           MYSQL_ROOT_PASSWORD: drupal
           MYSQL_USER: drupal
           MYSQL_PASSWORD: drupal
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Install Drupal
-        run: drush si --db-url=mysql://root:drupal@mariadb:3306/drupal11 -y
+        run: drush si --db-url=mysql://root:drupal@mariadb:3306/drupal -y
         working-directory: /var/www/drupal
 
       - name: Install module dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,11 @@
+# To add new Drupal versions, update quant-ci-images repo.
 name: Test and code coverage
 on:
   - push
 jobs:
   lint:
     runs-on: ubuntu-latest
-    container: quantcdn/drupal-ci:9.4.x-dev
+    container: quantcdn/drupal-ci:11.0.x-dev
     steps:
       - uses: actions/checkout@v2
       - name: Lint
@@ -12,7 +13,7 @@ jobs:
 
   phpunit:
     runs-on: ubuntu-latest
-    container: quantcdn/drupal-ci:9.4.x-dev
+    container: quantcdn/drupal-ci:11.0.x-dev
 
     services:
       mariadb:
@@ -20,7 +21,7 @@ jobs:
         ports:
           - 3306:3306
         env:
-          MYSQL_DATABASE: drupal9
+          MYSQL_DATABASE: drupal11
           MYSQL_ROOT_PASSWORD: drupal
           MYSQL_USER: drupal
           MYSQL_PASSWORD: drupal
@@ -32,7 +33,7 @@ jobs:
 
     steps:
       - name: Install Drupal
-        run: drush si --db-url=mysql://root:drupal@mariadb:3306/drupal9 -y
+        run: drush si --db-url=mysql://root:drupal@mariadb:3306/drupal11 -y
         working-directory: /var/www/drupal
 
       - name: Install module dependencies

--- a/modules/quant_api/quant_api.info.yml
+++ b/modules/quant_api/quant_api.info.yml
@@ -3,7 +3,7 @@ description: Connect to the hosted Quant service
 package: Quant
 
 type: module
-core_version_requirement: ^10.3 || ^11
+core_version_requirement: ^11
 configure: quant_api.settings_form
 dependencies:
   - drupal:quant

--- a/modules/quant_api/quant_api.info.yml
+++ b/modules/quant_api/quant_api.info.yml
@@ -3,7 +3,7 @@ description: Connect to the hosted Quant service
 package: Quant
 
 type: module
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^10 || ^11
 configure: quant_api.settings_form
 dependencies:
   - drupal:quant

--- a/modules/quant_api/quant_api.info.yml
+++ b/modules/quant_api/quant_api.info.yml
@@ -3,7 +3,7 @@ description: Connect to the hosted Quant service
 package: Quant
 
 type: module
-core_version_requirement: ^10 || ^11
+core_version_requirement: ^10.3 || ^11
 configure: quant_api.settings_form
 dependencies:
   - drupal:quant

--- a/modules/quant_api/src/Client/QuantClient.php
+++ b/modules/quant_api/src/Client/QuantClient.php
@@ -270,7 +270,7 @@ class QuantClient implements QuantClientInterface {
   /**
    * {@inheritdoc}
    */
-  public function sendFile(string $file, string $url, int $rid = NULL) : array {
+  public function sendFile(string $file, string $url, ?int $rid = NULL) : array {
 
     // Ensure the file is accessible before attempting to send to the API.
     if (!file_exists($file) || !is_readable($file) || !is_file($file)) {

--- a/modules/quant_api/src/Client/QuantClientInterface.php
+++ b/modules/quant_api/src/Client/QuantClientInterface.php
@@ -65,7 +65,7 @@ interface QuantClientInterface {
    * @throws \Drupal\quant_api\Exception\InvalidPayload
    * @throws \Drupal\quant_api\Exception\InvalidResposne
    */
-  public function sendFile(string $file, string $url, int $rid = NULL) : array;
+  public function sendFile(string $file, string $url, ?int $rid = NULL) : array;
 
   /**
    * Send a redirect to the API.

--- a/modules/quant_api/src/EventSubscriber/QuantApi.php
+++ b/modules/quant_api/src/EventSubscriber/QuantApi.php
@@ -64,7 +64,7 @@ class QuantApi implements EventSubscriberInterface {
   /**
    * {@inheritdoc}
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     $events[QuantEvent::OUTPUT] = ['onOutput', -999];
     $events[QuantFileEvent::OUTPUT] = ['onMedia', -999];
     $events[QuantRedirectEvent::UPDATE] = ['onRedirect', -999];

--- a/modules/quant_api/src/EventSubscriber/QuantApi.php
+++ b/modules/quant_api/src/EventSubscriber/QuantApi.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\quant_api\EventSubscriber;
 
-use Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\quant\Event\QuantEvent;
 use Drupal\quant\Event\QuantFileEvent;
@@ -14,6 +13,7 @@ use Drupal\quant\Seed;
 use Drupal\quant\Utility;
 use Drupal\quant_api\Client\QuantClientInterface;
 use Drupal\quant_api\Exception\InvalidPayload;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -38,7 +38,7 @@ class QuantApi implements EventSubscriberInterface {
   /**
    * The event dispatcher.
    *
-   * @var \Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher
+   * @var \Symfony\Component\EventDispatcher\EventDispatcher
    */
   protected $eventDispatcher;
 
@@ -52,10 +52,10 @@ class QuantApi implements EventSubscriberInterface {
    *   The Drupal HTTP Client to make requests.
    * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
    *   The logger channel factory.
-   * @param \Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher $event_dispatcher
+   * @param \Symfony\Component\EventDispatcher\EventDispatcher $event_dispatcher
    *   The event dispatcher.
    */
-  public function __construct(QuantClientInterface $client, LoggerChannelFactoryInterface $logger_factory, ContainerAwareEventDispatcher $event_dispatcher) {
+  public function __construct(QuantClientInterface $client, LoggerChannelFactoryInterface $logger_factory, EventDispatcher $event_dispatcher) {
     $this->client = $client;
     $this->logger = $logger_factory->get('quant_api');
     $this->eventDispatcher = $event_dispatcher;

--- a/modules/quant_api/tests/src/Unit/QuantClientTest.php
+++ b/modules/quant_api/tests/src/Unit/QuantClientTest.php
@@ -2,12 +2,13 @@
 
 namespace Drupal\Tests\quant_api\Unit;
 
-use Drupal\Tests\UnitTestCase;
-use Drupal\quant_api\Client\QuantClient;
-use GuzzleHttp\Client;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\ImmutableConfig;
+use Drupal\quant_api\Client\QuantClient;
+use Drupal\quant_api\Exception\InvalidPayload;
+use Drupal\Tests\UnitTestCase;
+use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\RequestOptions;
@@ -201,7 +202,7 @@ class QuantClientTest extends UnitTestCase {
    * Ensure that send handles server errors.
    */
   public function testSendError() {
-    $this->expectException(\GuzzleHttp\Exception\RequestException::class);
+    $this->expectException(RequestException::class);
     $http = $this->prophesize(Client::class);
     $logger = $this->prophesize(LoggerChannelFactoryInterface::class);
     $config = $this->getConfigStub();
@@ -255,7 +256,7 @@ class QuantClientTest extends UnitTestCase {
    * Ensure a valid redirect response is sent.
    */
   public function testSendRedirectError() {
-    $this->expectException(\GuzzleHttp\Exception\RequestException::class);
+    $this->expectException(RequestException::class);
     $http = $this->prophesize(Client::class);
     $logger = $this->prophesize(LoggerChannelFactoryInterface::class);
     $config = $this->getConfigStub();
@@ -278,7 +279,7 @@ class QuantClientTest extends UnitTestCase {
    * Ensure files are validated before sending.
    */
   public function testSendFileFileNoExist() {
-    $this->expectException(\Drupal\quant_api\Exception\InvalidPayload::class);
+    $this->expectException(InvalidPayload::class);
     // phpcs:ignore
     global $exists_return;
     // phpcs:ignore

--- a/modules/quant_api/tests/src/Unit/QuantClientTest.php
+++ b/modules/quant_api/tests/src/Unit/QuantClientTest.php
@@ -199,10 +199,9 @@ class QuantClientTest extends UnitTestCase {
 
   /**
    * Ensure that send handles server errors.
-   *
-   * @expectedException GuzzleHttp\Exception\RequestException
    */
   public function testSendError() {
+    $this->expectException(\GuzzleHttp\Exception\RequestException::class);
     $http = $this->prophesize(Client::class);
     $logger = $this->prophesize(LoggerChannelFactoryInterface::class);
     $config = $this->getConfigStub();
@@ -254,10 +253,9 @@ class QuantClientTest extends UnitTestCase {
 
   /**
    * Ensure a valid redirect response is sent.
-   *
-   * @expectedException GuzzleHttp\Exception\RequestException
    */
   public function testSendRedirectError() {
+    $this->expectException(\GuzzleHttp\Exception\RequestException::class);
     $http = $this->prophesize(Client::class);
     $logger = $this->prophesize(LoggerChannelFactoryInterface::class);
     $config = $this->getConfigStub();
@@ -278,10 +276,9 @@ class QuantClientTest extends UnitTestCase {
 
   /**
    * Ensure files are validated before sending.
-   *
-   * @expectedException Drupal\quant_api\Exception\InvalidPayload
    */
   public function testSendFileFileNoExist() {
+    $this->expectException(\Drupal\quant_api\Exception\InvalidPayload::class);
     // phpcs:ignore
     global $exists_return;
     // phpcs:ignore

--- a/modules/quant_cron/quant_cron.info.yml
+++ b/modules/quant_cron/quant_cron.info.yml
@@ -3,7 +3,7 @@ description: Run Quant tasks during cron
 package: Quant
 
 type: module
-core_version_requirement: ^10.3 || ^11
+core_version_requirement: ^11
 configure: quant_cron.settings_form
 dependencies:
   - quant:quant_api

--- a/modules/quant_cron/quant_cron.info.yml
+++ b/modules/quant_cron/quant_cron.info.yml
@@ -3,7 +3,7 @@ description: Run Quant tasks during cron
 package: Quant
 
 type: module
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^10 || ^11
 configure: quant_cron.settings_form
 dependencies:
   - quant:quant_api

--- a/modules/quant_cron/quant_cron.info.yml
+++ b/modules/quant_cron/quant_cron.info.yml
@@ -3,7 +3,7 @@ description: Run Quant tasks during cron
 package: Quant
 
 type: module
-core_version_requirement: ^10 || ^11
+core_version_requirement: ^10.3 || ^11
 configure: quant_cron.settings_form
 dependencies:
   - quant:quant_api

--- a/modules/quant_purger/quant_purger.info.yml
+++ b/modules/quant_purger/quant_purger.info.yml
@@ -3,7 +3,7 @@ description: Cache tag purger for Quant.
 package: Quant
 
 type: module
-core_version_requirement: ^10 || ^11
+core_version_requirement: ^10.3 || ^11
 
 dependencies:
   - quant:quant

--- a/modules/quant_purger/quant_purger.info.yml
+++ b/modules/quant_purger/quant_purger.info.yml
@@ -3,7 +3,7 @@ description: Cache tag purger for Quant.
 package: Quant
 
 type: module
-core_version_requirement: ^10.3 || ^11
+core_version_requirement: ^11
 
 dependencies:
   - quant:quant

--- a/modules/quant_purger/quant_purger.info.yml
+++ b/modules/quant_purger/quant_purger.info.yml
@@ -3,7 +3,7 @@ description: Cache tag purger for Quant.
 package: Quant
 
 type: module
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^10 || ^11
 
 dependencies:
   - quant:quant

--- a/modules/quant_purger/src/StackMiddleware/UrlRegistrar.php
+++ b/modules/quant_purger/src/StackMiddleware/UrlRegistrar.php
@@ -57,7 +57,7 @@ if (empty($method->getReturnType())) {
     /**
      * {@inheritdoc}
      */
-    public function handle(Request $request, $type = self::MASTER_REQUEST, $catch = TRUE) {
+    public function handle(Request $request, $type = self::MAIN_REQUEST, $catch = TRUE) {
       $response = $this->httpKernel->handle($request, $type, $catch);
       if ($this->determine($request, $response)) {
         $this->registry->add(

--- a/modules/quant_search/quant_search.info.yml
+++ b/modules/quant_search/quant_search.info.yml
@@ -3,7 +3,7 @@ description: 'Allows creation of Quant Search pages.'
 package: Quant
 
 type: module
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^10 || ^11
 configure: quant_search.main
 dependencies:
   - drupal:quant

--- a/modules/quant_search/quant_search.info.yml
+++ b/modules/quant_search/quant_search.info.yml
@@ -3,7 +3,7 @@ description: 'Allows creation of Quant Search pages.'
 package: Quant
 
 type: module
-core_version_requirement: ^10.3 || ^11
+core_version_requirement: ^11
 configure: quant_search.main
 dependencies:
   - drupal:quant

--- a/modules/quant_search/quant_search.info.yml
+++ b/modules/quant_search/quant_search.info.yml
@@ -3,7 +3,7 @@ description: 'Allows creation of Quant Search pages.'
 package: Quant
 
 type: module
-core_version_requirement: ^10 || ^11
+core_version_requirement: ^10.3 || ^11
 configure: quant_search.main
 dependencies:
   - drupal:quant

--- a/modules/quant_search/src/EventSubscriber/SearchEventSubscriber.php
+++ b/modules/quant_search/src/EventSubscriber/SearchEventSubscriber.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\quant_search\EventSubscriber;
 
-use Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\quant\Event\QuantEvent;
 use Drupal\quant_search\Controller\Search;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -23,7 +23,7 @@ class SearchEventSubscriber implements EventSubscriberInterface {
   /**
    * The event dispatcher.
    *
-   * @var \Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher
+   * @var \Symfony\Component\EventDispatcher\EventDispatcher
    */
   protected $eventDispatcher;
 
@@ -34,10 +34,10 @@ class SearchEventSubscriber implements EventSubscriberInterface {
    *
    * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
    *   The logger channel factory.
-   * @param \Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher $event_dispatcher
+   * @param \Symfony\Component\EventDispatcher\EventDispatcher $event_dispatcher
    *   The event dispatcher.
    */
-  public function __construct(LoggerChannelFactoryInterface $logger_factory, ContainerAwareEventDispatcher $event_dispatcher) {
+  public function __construct(LoggerChannelFactoryInterface $logger_factory, EventDispatcher $event_dispatcher) {
     $this->logger = $logger_factory->get('quant_search');
     $this->eventDispatcher = $event_dispatcher;
   }

--- a/modules/quant_search/src/EventSubscriber/SearchEventSubscriber.php
+++ b/modules/quant_search/src/EventSubscriber/SearchEventSubscriber.php
@@ -45,7 +45,7 @@ class SearchEventSubscriber implements EventSubscriberInterface {
   /**
    * {@inheritdoc}
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     $events[QuantEvent::OUTPUT] = ['onOutput', 1];
     return $events;
   }

--- a/modules/quant_search/src/Form/ConfirmIndexClearForm.php
+++ b/modules/quant_search/src/Form/ConfirmIndexClearForm.php
@@ -14,7 +14,7 @@ class ConfirmIndexClearForm extends ConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state, string $id = NULL) {
+  public function buildForm(array $form, FormStateInterface $form_state, ?string $id = NULL) {
     return parent::buildForm($form, $form_state);
   }
 

--- a/modules/quant_sitemap/quant_sitemap.info.yml
+++ b/modules/quant_sitemap/quant_sitemap.info.yml
@@ -3,7 +3,7 @@ description: Quant simple_sitemap support
 package: Quant
 
 type: module
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^10 || ^11
 
 dependencies:
   - quant:quant_api

--- a/modules/quant_sitemap/quant_sitemap.info.yml
+++ b/modules/quant_sitemap/quant_sitemap.info.yml
@@ -3,7 +3,7 @@ description: Quant simple_sitemap support
 package: Quant
 
 type: module
-core_version_requirement: ^10.3 || ^11
+core_version_requirement: ^11
 
 dependencies:
   - quant:quant_api

--- a/modules/quant_sitemap/quant_sitemap.info.yml
+++ b/modules/quant_sitemap/quant_sitemap.info.yml
@@ -3,7 +3,7 @@ description: Quant simple_sitemap support
 package: Quant
 
 type: module
-core_version_requirement: ^10 || ^11
+core_version_requirement: ^10.3 || ^11
 
 dependencies:
   - quant:quant_api

--- a/modules/quant_sitemap/src/EventSubscriber/CollectionSubscriber.php
+++ b/modules/quant_sitemap/src/EventSubscriber/CollectionSubscriber.php
@@ -37,7 +37,7 @@ class CollectionSubscriber implements EventSubscriberInterface {
   /**
    * {@inheritdoc}
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     $events[QuantCollectionEvents::ROUTES][] = ['collectRoutes'];
     return $events;
   }

--- a/modules/quant_sitemap/tests/src/Unit/SitemapManagerTest.php
+++ b/modules/quant_sitemap/tests/src/Unit/SitemapManagerTest.php
@@ -37,9 +37,7 @@ class SitemapManagerTest extends KernelTestBase {
       ->with('simple_sitemap')
       ->willReturn($module);
 
-    $entity_manager_mock = $this->getMockBuilder(EntityTypeManager::class)
-      ->disableOriginalConstructor()
-      ->getMock();
+    $entity_manager_mock = $this->createMock(EntityTypeManager::class);
 
     $manager = new SitemapManager($module_handler_mock, $entity_manager_mock, $module_list_mock);
     $result = $manager->isAvailable();
@@ -67,9 +65,7 @@ class SitemapManagerTest extends KernelTestBase {
       ->with('simple_sitemap')
       ->willReturn($module);
 
-    $entity_manager_mock = $this->getMockBuilder(EntityTypeManager::class)
-      ->disableOriginalConstructor()
-      ->getMock();
+    $entity_manager_mock = $this->createMock(EntityTypeManager::class);
 
     $manager = new SitemapManager($module_handler_mock, $entity_manager_mock, $module_list_mock);
     $result = $manager->isAvailable();
@@ -97,9 +93,7 @@ class SitemapManagerTest extends KernelTestBase {
       ->with('xmlsitemap')
       ->willReturn($module);
 
-    $entity_manager_mock = $this->getMockBuilder(EntityTypeManager::class)
-      ->disableOriginalConstructor()
-      ->getMock();
+    $entity_manager_mock = $this->createMock(EntityTypeManager::class);
 
     $manager = new SitemapManager($module_handler_mock, $entity_manager_mock, $module_list_mock);
     $result = $manager->isAvailable();
@@ -127,9 +121,7 @@ class SitemapManagerTest extends KernelTestBase {
       ->with('xmlsitemap')
       ->willReturn($module);
 
-    $entity_manager_mock = $this->getMockBuilder(EntityTypeManager::class)
-      ->disableOriginalConstructor()
-      ->getMock();
+    $entity_manager_mock = $this->createMock(EntityTypeManager::class);
 
     $manager = new SitemapManager($module_handler_mock, $entity_manager_mock, $module_list_mock);
     $result = $manager->isAvailable();
@@ -157,7 +149,6 @@ class SitemapManagerTest extends KernelTestBase {
         $entity_manager_mock,
         $module_list_mock,
       ])
-      ->setMethods(['isAvailable'])
       ->getMock();
 
     $manager->expects($this->once())
@@ -197,7 +188,6 @@ class SitemapManagerTest extends KernelTestBase {
         $entity_manager_mock,
         $module_list_mock,
       ])
-      ->setMethods(['isAvailable', 'getSitemapManager'])
       ->getMock();
 
     $manager->expects($this->once())

--- a/modules/quant_sitemap/tests/src/Unit/SitemapManagerTest.php
+++ b/modules/quant_sitemap/tests/src/Unit/SitemapManagerTest.php
@@ -37,7 +37,9 @@ class SitemapManagerTest extends KernelTestBase {
       ->with('simple_sitemap')
       ->willReturn($module);
 
-    $entity_manager_mock = $this->createMock(EntityTypeManager::class);
+    $entity_manager_mock = $this->getMockBuilder(EntityTypeManager::class)
+      ->disableOriginalConstructor()
+      ->getMock();
 
     $manager = new SitemapManager($module_handler_mock, $entity_manager_mock, $module_list_mock);
     $result = $manager->isAvailable();
@@ -65,7 +67,9 @@ class SitemapManagerTest extends KernelTestBase {
       ->with('simple_sitemap')
       ->willReturn($module);
 
-    $entity_manager_mock = $this->createMock(EntityTypeManager::class);
+    $entity_manager_mock = $this->getMockBuilder(EntityTypeManager::class)
+      ->disableOriginalConstructor()
+      ->getMock();
 
     $manager = new SitemapManager($module_handler_mock, $entity_manager_mock, $module_list_mock);
     $result = $manager->isAvailable();
@@ -93,7 +97,9 @@ class SitemapManagerTest extends KernelTestBase {
       ->with('xmlsitemap')
       ->willReturn($module);
 
-    $entity_manager_mock = $this->createMock(EntityTypeManager::class);
+    $entity_manager_mock = $this->getMockBuilder(EntityTypeManager::class)
+      ->disableOriginalConstructor()
+      ->getMock();
 
     $manager = new SitemapManager($module_handler_mock, $entity_manager_mock, $module_list_mock);
     $result = $manager->isAvailable();
@@ -121,7 +127,9 @@ class SitemapManagerTest extends KernelTestBase {
       ->with('xmlsitemap')
       ->willReturn($module);
 
-    $entity_manager_mock = $this->createMock(EntityTypeManager::class);
+    $entity_manager_mock = $this->getMockBuilder(EntityTypeManager::class)
+      ->disableOriginalConstructor()
+      ->getMock();
 
     $manager = new SitemapManager($module_handler_mock, $entity_manager_mock, $module_list_mock);
     $result = $manager->isAvailable();
@@ -149,6 +157,7 @@ class SitemapManagerTest extends KernelTestBase {
         $entity_manager_mock,
         $module_list_mock,
       ])
+      ->onlyMethods(['isAvailable'])
       ->getMock();
 
     $manager->expects($this->once())
@@ -188,6 +197,7 @@ class SitemapManagerTest extends KernelTestBase {
         $entity_manager_mock,
         $module_list_mock,
       ])
+      ->onlyMethods(['isAvailable', 'getSitemapManager'])
       ->getMock();
 
     $manager->expects($this->once())

--- a/modules/quant_tome/quant_tome.info.yml
+++ b/modules/quant_tome/quant_tome.info.yml
@@ -3,7 +3,7 @@ description: 'Deploy Tome static output to Quant.'
 package: Quant
 
 type: module
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^10 || ^11
 
 dependencies:
 - tome:tome_static

--- a/modules/quant_tome/quant_tome.info.yml
+++ b/modules/quant_tome/quant_tome.info.yml
@@ -3,7 +3,7 @@ description: 'Deploy Tome static output to Quant.'
 package: Quant
 
 type: module
-core_version_requirement: ^10.3 || ^11
+core_version_requirement: ^11
 
 dependencies:
 - tome:tome_static

--- a/modules/quant_tome/quant_tome.info.yml
+++ b/modules/quant_tome/quant_tome.info.yml
@@ -3,7 +3,7 @@ description: 'Deploy Tome static output to Quant.'
 package: Quant
 
 type: module
-core_version_requirement: ^10 || ^11
+core_version_requirement: ^10.3 || ^11
 
 dependencies:
 - tome:tome_static

--- a/modules/quant_tome/src/EventSubscriber/RedirectSubscriber.php
+++ b/modules/quant_tome/src/EventSubscriber/RedirectSubscriber.php
@@ -60,7 +60,7 @@ class RedirectSubscriber implements EventSubscriberInterface {
   /**
    * {@inheritdoc}
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     $events[KernelEvents::RESPONSE][] = ['onResponse'];
     return $events;
   }

--- a/modules/quant_webform/quant_webform.info.yml
+++ b/modules/quant_webform/quant_webform.info.yml
@@ -3,7 +3,7 @@ description: Quant Form support for Webform
 package: Quant
 
 type: module
-core_version_requirement: ^10 || ^11
+core_version_requirement: ^10.3 || ^11
 
 dependencies:
   - quant:quant

--- a/modules/quant_webform/quant_webform.info.yml
+++ b/modules/quant_webform/quant_webform.info.yml
@@ -3,7 +3,7 @@ description: Quant Form support for Webform
 package: Quant
 
 type: module
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^10 || ^11
 
 dependencies:
   - quant:quant

--- a/modules/quant_webform/quant_webform.info.yml
+++ b/modules/quant_webform/quant_webform.info.yml
@@ -3,7 +3,7 @@ description: Quant Form support for Webform
 package: Quant
 
 type: module
-core_version_requirement: ^10.3 || ^11
+core_version_requirement: ^11
 
 dependencies:
   - quant:quant

--- a/quant.info.yml
+++ b/quant.info.yml
@@ -3,7 +3,7 @@ description: Quant content export
 package: Quant
 
 type: module
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^10 || ^11
 configure: quant.config
 dependencies:
   - drupal:taxonomy

--- a/quant.info.yml
+++ b/quant.info.yml
@@ -3,7 +3,7 @@ description: Quant content export
 package: Quant
 
 type: module
-core_version_requirement: ^10.3 || ^11
+core_version_requirement: ^11
 configure: quant.config
 dependencies:
   - drupal:taxonomy

--- a/quant.info.yml
+++ b/quant.info.yml
@@ -3,7 +3,7 @@ description: Quant content export
 package: Quant
 
 type: module
-core_version_requirement: ^10 || ^11
+core_version_requirement: ^10.3 || ^11
 configure: quant.config
 dependencies:
   - drupal:taxonomy

--- a/quant.module
+++ b/quant.module
@@ -17,6 +17,7 @@ use Drupal\quant\Plugin\QueueItem\RouteItem;
 use Drupal\quant\QuantQueueFactory;
 use Drupal\quant\Seed;
 use Drupal\quant\Utility;
+use Drupal\views\ViewExecutable;
 
 /**
  * Implements hook_menu_local_tasks_alter().
@@ -499,5 +500,18 @@ function quant_preprocess_views_view_table(&$variables) {
       // $variables['rows'][$id]['attributes']->addClass('messages');
       // $variables['rows'][$id]['attributes']->addClass('messages--warning');
     }
+  }
+}
+
+/**
+ * Implements hook_preprocess_views_view().
+ */
+function quant_preprocess_views_view(array &$variables) {
+  /** @var ViewExecutable $view */
+  $view = $variables['view'];
+
+  // If the view has exposed filters, add a warning for admins.
+  if ($view->exposed_data && \Drupal::currentUser()->hasRole('administrator')) {
+    \Drupal::messenger()->addWarning(t('The view (@view_id) on this page has exposed filters which need special handling for a static website.<br/> <a href="https://docs.quantcdn.io/integrations/drupal">Review the documentation for your options</a>.', ['@view_id' => $view->id()]));
   }
 }

--- a/src/Controller/QuantNodeViewController.php
+++ b/src/Controller/QuantNodeViewController.php
@@ -53,7 +53,7 @@ class QuantNodeViewController extends NodeViewController {
    * @param \Drupal\Core\Session\AccountSwitcherInterface $account_switcher
    *   The account switcher interface.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, RendererInterface $renderer, AccountInterface $current_user = NULL, EntityRepositoryInterface $entity_repository = NULL, RequestStack $request_stack, CurrentRouteMatch $route_match, AccountSwitcherInterface $account_switcher) {
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, RendererInterface $renderer, ?AccountInterface $current_user = NULL, ?EntityRepositoryInterface $entity_repository = NULL, RequestStack $request_stack, CurrentRouteMatch $route_match, AccountSwitcherInterface $account_switcher) {
     parent::__construct($entity_type_manager, $renderer, $current_user, $entity_repository);
 
     $this->accountSwitcher = $account_switcher;

--- a/src/Event/ConfigFormEventBase.php
+++ b/src/Event/ConfigFormEventBase.php
@@ -36,7 +36,7 @@ class ConfigFormEventBase extends Event implements ConfigFormEventInterface {
   /**
    * {@inheritdoc}
    */
-  public function __construct(FormStateInterface $form_state = NULL) {
+  public function __construct(?FormStateInterface $form_state = NULL) {
     $this->formState = $form_state;
   }
 

--- a/src/Event/ConfigFormEventInterface.php
+++ b/src/Event/ConfigFormEventInterface.php
@@ -15,7 +15,7 @@ interface ConfigFormEventInterface {
    * @param Drupal\Core\Form\FormStateInterface $form_state
    *   The configuration values.
    */
-  public function __construct(FormStateInterface $form_state = NULL);
+  public function __construct(?FormStateInterface $form_state = NULL);
 
   /**
    * Accessor for the form state.

--- a/src/EventSubscriber/CollectionSubscriber.php
+++ b/src/EventSubscriber/CollectionSubscriber.php
@@ -48,7 +48,7 @@ class CollectionSubscriber implements EventSubscriberInterface {
   /**
    * {@inheritdoc}
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     $events[QuantCollectionEvents::ENTITIES][] = ['collectEntities'];
     $events[QuantCollectionEvents::TAXONOMY_TERMS][] = ['collectTaxonomyTerms'];
     $events[QuantCollectionEvents::FILES][] = ['collectFiles'];

--- a/src/EventSubscriber/NodeInsertSubscriber.php
+++ b/src/EventSubscriber/NodeInsertSubscriber.php
@@ -45,7 +45,7 @@ class NodeInsertSubscriber implements EventSubscriberInterface {
   /**
    * {@inheritdoc}
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     $events[NodeInsertEvent::NODE_INSERT_EVENT][] = ['onNodeInsert'];
     return $events;
   }

--- a/src/EventSubscriber/TokenAccessSubscriber.php
+++ b/src/EventSubscriber/TokenAccessSubscriber.php
@@ -43,7 +43,7 @@ class TokenAccessSubscriber implements EventSubscriberInterface {
   /**
    * {@inheritdoc}
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     $events[KernelEvents::REQUEST][] = ['validateToken'];
     return $events;
   }

--- a/src/Exception/ExpiredTokenException.php
+++ b/src/Exception/ExpiredTokenException.php
@@ -31,7 +31,7 @@ class ExpiredTokenException extends \Exception {
   /**
    * {@inheritdoc}
    */
-  public function __construct(string $token, int $time = 0, $sTime = 0, string $message = "The token has expired", int $code = 0, \Throwable $previous = NULL) {
+  public function __construct(string $token, int $time = 0, $sTime = 0, string $message = "The token has expired", int $code = 0, ?\Throwable $previous = NULL) {
     $this->token = $token;
     $this->time = $time;
     $this->sTime = $sTime;

--- a/src/Exception/InvalidTokenException.php
+++ b/src/Exception/InvalidTokenException.php
@@ -24,7 +24,7 @@ class InvalidTokenException extends \Exception {
   /**
    * {@inheritdoc}
    */
-  public function __construct(string $token, int $time = 0, string $message = "Invalid request token", int $code = 0, \Throwable $previous = NULL) {
+  public function __construct(string $token, int $time = 0, string $message = "Invalid request token", int $code = 0, ?\Throwable $previous = NULL) {
     $this->token = $token;
     $this->time = $time;
 

--- a/src/Exception/StrictTokenException.php
+++ b/src/Exception/StrictTokenException.php
@@ -31,7 +31,7 @@ class StrictTokenException extends \Exception {
   /**
    * {@inheritdoc}
    */
-  public function __construct(string $token, $token_route = NULL, $expected_route = NULL, string $message = "The token routes do not match", int $code = 0, \Throwable $previous = NULL) {
+  public function __construct(string $token, $token_route = NULL, $expected_route = NULL, string $message = "The token routes do not match", int $code = 0, ?\Throwable $previous = NULL) {
     $this->token = $token;
     $this->tokenRoute = $token_route;
     $this->expectedRoute = $expected_route;

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -45,7 +45,7 @@ class Utility {
    * @return string
    *   The URL adjusted for multilingual settings. Defaults to current url.
    */
-  public static function getUrl(string $url = NULL, string $langcode = NULL) : string {
+  public static function getUrl(?string $url = NULL, ?string $langcode = NULL) : string {
 
     // Default to current URL.
     if (!$url) {
@@ -77,7 +77,7 @@ class Utility {
    * @return string
    *   The path prefix based on multilingual settings. Defaults to '/'.
    */
-  public static function getPathPrefix(string $langcode = NULL) : string {
+  public static function getPathPrefix(?string $langcode = NULL) : string {
 
     // Always start with a slash.
     $prefix = '/';
@@ -200,7 +200,7 @@ class Utility {
    * @return string
    *   The markup with the page info.
    */
-  public static function getPageInfo(array $urls = NULL) : string {
+  public static function getPageInfo(?array $urls = NULL) : string {
     try {
       // Only allow administrators and content editors access.
       $roles = ['administrator', 'content_editor', 'editor'];


### PR DESCRIPTION
Drupal CMS has a blog page out of the box that has an exposed filter so this is a work around so people don't think it's broken for now good reason.

We should aad follow up docs on options to handle the page:

1. Route the url to origin rather than being static
2. Redo the view to not have exposed filters
3. Redo the page to use Algolia search facets
4. If there are a very small number of filters, disable ajax and each permutation of results can be generated as static page

