### PR TITLE
Ensure translation is loaded via getTranslation().

### DIFF
--- a/modules/quant_cron/quant_cron.module
+++ b/modules/quant_cron/quant_cron.module
@@ -70,7 +70,8 @@ function quant_cron_cron() {
         if (!empty($filter) && !in_array($langcode, $filter)) {
           continue;
         }
-        Seed::seedNode($entity, $langcode);
+        $translated_entity = $entity->getTranslation($langcode);
+        Seed::seedNode($translated_entity, $langcode);
 
         \Drupal::logger('quant_cron')->notice("quant_cron sending node: nid: @nid, langcode: @lang",
           [
@@ -92,7 +93,8 @@ function quant_cron_cron() {
       $term = Term::load($tid);
 
       foreach ($term->getTranslationLanguages() as $langcode => $language) {
-        Seed::seedTaxonomyTerm($term, $langcode);
+        $translated_term = $term->getTranslation($langcode);
+        Seed::seedTaxonomyTerm($translated_term, $langcode);
 
         \Drupal::logger('quant_cron')->notice("quant_cron sending term: tid: @tid, langcode: @lang",
           [

--- a/modules/quant_cron/quant_cron.module
+++ b/modules/quant_cron/quant_cron.module
@@ -70,8 +70,7 @@ function quant_cron_cron() {
         if (!empty($filter) && !in_array($langcode, $filter)) {
           continue;
         }
-        $translated_entity = $entity->getTranslation($langcode);
-        Seed::seedNode($translated_entity, $langcode);
+        Seed::seedNode($entity, $langcode);
 
         \Drupal::logger('quant_cron')->notice("quant_cron sending node: nid: @nid, langcode: @lang",
           [
@@ -93,8 +92,7 @@ function quant_cron_cron() {
       $term = Term::load($tid);
 
       foreach ($term->getTranslationLanguages() as $langcode => $language) {
-        $translated_term = $term->getTranslation($langcode);
-        Seed::seedTaxonomyTerm($translated_term, $langcode);
+        Seed::seedTaxonomyTerm($term, $langcode);
 
         \Drupal::logger('quant_cron')->notice("quant_cron sending term: tid: @tid, langcode: @lang",
           [

--- a/src/Plugin/QueueItem/NodeItem.php
+++ b/src/Plugin/QueueItem/NodeItem.php
@@ -60,11 +60,33 @@ class NodeItem implements QuantQueueItemInterface {
       $entity = \Drupal::entityTypeManager()->getStorage('node')->loadRevision($this->vid);
     }
 
+    if (!$entity) {
+      \Drupal::logger('quant')->error(
+        'Failed to load entity for node ID: @id, revision ID: @vid',
+        [
+          '@id' => $this->id,
+          '@vid' => $this->vid,
+        ]
+      );
+      return;
+    }
+
     foreach ($entity->getTranslationLanguages() as $langcode => $language) {
       if (!empty($this->filter) && !in_array($langcode, $this->filter)) {
         continue;
       }
-      Seed::seedNode($entity, $langcode);
+
+      \Drupal::logger('quant_seed')->notice(
+        'Processing language @langcode for node @id',
+        [
+          '@langcode' => $langcode,
+          '@id' => $this->id,
+        ]
+      );
+
+      // getTranslation provides more accurate published status.
+      $translated_entity = $entity->getTranslation($langcode);
+      Seed::seedNode($translated_entity, $langcode);
     }
   }
 

--- a/src/Plugin/QueueItem/NodeItem.php
+++ b/src/Plugin/QueueItem/NodeItem.php
@@ -61,7 +61,7 @@ class NodeItem implements QuantQueueItemInterface {
     }
 
     if (!$entity) {
-      \Drupal::logger('quant')->error(
+      \Drupal::logger('quant_seed')->error(
         'Failed to load entity for node ID: @id, revision ID: @vid',
         [
           '@id' => $this->id,
@@ -76,7 +76,7 @@ class NodeItem implements QuantQueueItemInterface {
         continue;
       }
 
-      \Drupal::logger('quant')->notice(
+      \Drupal::logger('quant_seed')->notice(
         'Processing language @langcode for node @id',
         [
           '@langcode' => $langcode,

--- a/src/Plugin/QueueItem/NodeItem.php
+++ b/src/Plugin/QueueItem/NodeItem.php
@@ -76,7 +76,7 @@ class NodeItem implements QuantQueueItemInterface {
         continue;
       }
 
-      \Drupal::logger('quant_seed')->notice(
+      \Drupal::logger('quant')->notice(
         'Processing language @langcode for node @id',
         [
           '@langcode' => $langcode,
@@ -84,9 +84,7 @@ class NodeItem implements QuantQueueItemInterface {
         ]
       );
 
-      // getTranslation provides more accurate published status.
-      $translated_entity = $entity->getTranslation($langcode);
-      Seed::seedNode($translated_entity, $langcode);
+      Seed::seedNode($entity, $langcode);
     }
   }
 

--- a/src/Seed.php
+++ b/src/Seed.php
@@ -212,6 +212,10 @@ class Seed {
    * Seeds taxonomy term.
    */
   public static function seedTaxonomyTerm($entity, $langcode = NULL) {
+
+    // Use the translation to ensure correct metadata such as published state.
+    $entity = $entity->getTranslation($langcode);
+
     $tid = $entity->get('tid')->value;
 
     $url = Utility::getCanonicalUrl('taxonomy_term', $tid, $langcode);
@@ -263,6 +267,9 @@ class Seed {
    *   The node language.
    */
   public static function seedNode(EntityInterface $entity, $langcode = NULL) {
+
+    // Use the translation to ensure correct metadata such as published state.
+    $entity = $entity->getTranslation($langcode);
 
     $nid = $entity->get('nid')->value;
     $rid = $entity->get('vid')->value;


### PR DESCRIPTION
When `$entity->isPublished()` is used in Seed.php it is returning the default language published state, rather than the translated revision.

By passing in an entity loaded via `getTranslation` we get the true published status of the translated revision.

(This behaviour appears to have been introduced in a relatively recent version of Drupal core).